### PR TITLE
Add chroot support for 3.0 format

### DIFF
--- a/sections/chroot.zsh
+++ b/sections/chroot.zsh
@@ -1,0 +1,35 @@
+#
+# Chroot environment name
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_CHROOT_SHOW="${SPACESHIP_CHROOT_SHOW:=true}"
+SPACESHIP_CHROOT_PREFIX="${SPACESHIP_CHROOT_PREFIX:="using "}"
+SPACESHIP_CHROOT_SUFFIX="${SPACESHIP_CHROOT_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_CHROOT_COLOR="${SPACESHIP_CHROOT_COLOR:="magenta"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# If logged in to a chroot environment, display the name in the prompt
+spaceship_chroot() {
+  [[ $SPACESHIP_CHROOT_SHOW == false ]] && return
+
+  local debian_chroot
+
+  if [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+  fi
+
+  [[ -z "$debian_chroot" ]] && return
+
+  _prompt_section \
+    "$SPACESHIP_CHROOT_COLOR" \
+    "$SPACESHIP_CHROOT_PREFIX" \
+    "$debian_chroot" \
+    "$SPACESHIP_CHROOT_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -41,6 +41,7 @@ fi
 if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
   SPACESHIP_PROMPT_ORDER=(
     time          # Time stampts section
+    chroot        # Chroot section
     user          # Username section
     dir           # Current directory section
     host          # Hostname section


### PR DESCRIPTION
Adding chroot support for version v3 is an integration of the changes from https://github.com/nomaed/spaceship-zsh-theme/tree/debian-chroot-support for v2 into the new format. 

Part of issue https://github.com/denysdovhan/spaceship-zsh-theme/pull/222
All details in the thread.