### PR TITLE
Add docker-compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Currently it shows:
 * Current version of Haskell Tool Stack (`λ`)
 * Current Julia version (`ஃ`)
 * Current Docker version and connected machine (`🐳`).
+* Current Docker-compose status of each service (`🐙 `).
 * Current Amazon Web Services (AWS) profile (`☁️`) ([Using named profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html))
 * Current Python virtualenv.
 * Current Conda virtualenv (`🅒 `).
@@ -183,6 +184,7 @@ SPACESHIP_PROMPT_ORDER=(
   haskell       # Haskell Stack section
   julia         # Julia section
   docker        # Docker section
+  dockercompose # Docker-compose section
   aws           # Amazon Web Services section
   venv          # virtualenv section
   conda         # conda virtualenv section
@@ -487,6 +489,19 @@ Docker section is shown only in directories that contain `Dockerfile` or `docker
 | `SPACESHIP_DOCKER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker section |
 | `SPACESHIP_DOCKER_SYMBOL` | `🐳 ` | Character to be shown before Docker version |
 | `SPACESHIP_DOCKER_COLOR` | `cyan` | Color of Docker section |
+
+### Docker-compose (`dockercompose`)
+
+Docker-compose section is shown only in directories that contain a `docker-compose.yml` file.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_DOCKERCOMPOSE_SHOW` | `true` | Show current Docker-compose services status or not |
+| `SPACESHIP_DOCKERCOMPOSE_PREFIX` | `with ` | Prefix before the Docker-compose section |
+| `SPACESHIP_DOCKERCOMPOSE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker-compose section |
+| `SPACESHIP_DOCKERCOMPOSE_SYMBOL` | `🐙 ` | Character to be shown before Docker-compose status |
+| `SPACESHIP_DOCKERCOMPOSE_UP_COLOR` | `green` | Color of service that is up |
+| `SPACESHIP_DOCKERCOMPOSE_DOWN_COLOR` | `red` | Color of service that is down |
 
 ### Amazon Web Services (AWS) (`aws`)
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -34,6 +34,7 @@ if [ ! -n "$SPACESHIP_PROMPT_ORDER" ]; then
     haskell
     julia
     docker
+    dockercompose
     aws
     venv
     conda
@@ -221,6 +222,14 @@ SPACESHIP_DOCKER_PREFIX="${SPACESHIP_DOCKER_PREFIX:="on "}"
 SPACESHIP_DOCKER_SUFFIX="${SPACESHIP_DOCKER_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_DOCKER_SYMBOL="${SPACESHIP_DOCKER_SYMBOL:="🐳 "}"
 SPACESHIP_DOCKER_COLOR="${SPACESHIP_DOCKER_COLOR:="cyan"}"
+
+# DOCKER COMPOSE
+SPACESHIP_DOCKERCOMPOSE_SHOW="${SPACESHIP_DOCKERCOMPOSE_SHOW:=true}"
+SPACESHIP_DOCKERCOMPOSE_PREFIX="${SPACESHIP_DOCKERCOMPOSE_PREFIX:="with "}"
+SPACESHIP_DOCKERCOMPOSE_SUFFIX="${SPACESHIP_DOCKERCOMPOSE_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_DOCKERCOMPOSE_SYMBOL="${SPACESHIP_DOCKERCOMPOSE_SYMBOL:="🐙  "}"
+SPACESHIP_DOCKERCOMPOSE_UP_COLOR="${SPACESHIP_DOCKERCOMPOSE_UP_COLOR:="green"}"
+SPACESHIP_DOCKERCOMPOSE_DOWN_COLOR="${SPACESHIP_DOCKERCOMPOSE_DOWN_COLOR:="red"}"
 
 # VENV
 SPACESHIP_VENV_SHOW="${SPACESHIP_VENV_SHOW:=true}"
@@ -914,6 +923,36 @@ spaceship_docker() {
     "$SPACESHIP_DOCKER_PREFIX" \
     "${SPACESHIP_DOCKER_SYMBOL}v${docker_version}" \
     "$SPACESHIP_DOCKER_SUFFIX"
+}
+
+# DOCKERCOMPOSE
+# Show current docker-compose status
+spaceship_dockercompose() {
+  [[ $SPACESHIP_DOCKERCOMPOSE_SHOW == false ]] && return
+
+  _exists docker-compose || return
+
+  # Show Docker-compose status when docker-compose file exists
+  [[ -f docker-compose.yml ]] || return
+
+  local dockercompose_status
+
+  docker-compose ps 2>/dev/null | tail -n+3 | while read line
+  do
+    CONTAINER_LETTER_POSITION=$(echo $line | awk 'match($0,"_"){print RSTART}')
+    CONTAINER_LETTER=$(echo ${line:$CONTAINER_LETTER_POSITION:1} | tr '[:lower:]' '[:upper:]')
+    if [[ $line == *"Up"* ]]; then
+      dockercompose_status+="%{$fg_bold[$SPACESHIP_DOCKERCOMPOSE_UP_COLOR]%}"$CONTAINER_LETTER""
+    else
+      dockercompose_status+="%{$fg_bold[$SPACESHIP_DOCKERCOMPOSE_DOWN_COLOR]%}"$CONTAINER_LETTER""
+    fi
+  done
+
+  _prompt_section \
+    "" \
+    "$SPACESHIP_DOCKERCOMPOSE_PREFIX" \
+    "${SPACESHIP_DOCKERCOMPOSE_SYMBOL}${dockercompose_status}" \
+    "$SPACESHIP_DOCKERCOMPOSE_SUFFIX"
 }
 
 # Amazon Web Services (AWS)


### PR DESCRIPTION
Add support for showing the status of the docker-compose services. Since this can get verbose quickly, it uses the first letter of the servicename and the (by default) colours green and red to indicate a single service status.
Since the docker-compose logo is an octopus juggling containers, I've used 🐙 as the default prefix symbol.

It was inspired/loosely copied from https://github.com/sroze/docker-compose-zsh-plugin

It looks like this:
<img width="669" alt="screenshot 2018-01-02 22 04 54" src="https://user-images.githubusercontent.com/106844/34499994-24e2aa0c-f009-11e7-9d38-89a39476d9ff.png">

The README is also updated with all the options.

Let me know if I should rebase against 3.0