### PR TITLE
add git index indicators (take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently it shows:
 
 * Clever hostname and username displaying.
 * Prompt character turns red if the last command exits with non-zero code.
-* Current Git branch and rich repo status:
+* Current Git branch, index, and rich repo status:
   * `?` — untracked changes;
   * `+` — uncommitted changes in the index;
   * `!` — unstaged changes;
@@ -30,12 +30,14 @@ Currently it shows:
   * `=` — unmerged changes;
   * `⇡` — ahead of remote branch;
   * `⇣` — behind of remote branch;
-  * `⇕` — diverged chages.
+  * `⇕` — diverged changes;
+  * `⤒` - at least one file is assumed unchanged;
+  * `↧` - at least one file is skipped in the worktree.
 * Current Mercurial bookmark/branch and rich repo status:
   * `?` — untracked changes;
   * `+` — uncommitted changes in the index;
   * `!` — unstaged changes;
-  * `✘` — deleted files;
+  * `✘` — deleted files.
 * Indicator for jobs in the background (`✦`).
 * Current Node.js version, through nvm/nodenv/n (`⬢`).
 * Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -178,6 +178,8 @@ Git status indicators is shown only when you have dirty repository.
 | `SPACESHIP_GIT_STATUS_AHEAD` | `⇡` | Indicator for unpushed changes (ahead of remote branch) |
 | `SPACESHIP_GIT_STATUS_BEHIND` | `⇣` | Indicator for unpulled changes (behind of remote branch) |
 | `SPACESHIP_GIT_STATUS_DIVERGED` | `⇕` | Indicator for diverged chages (diverged with remote branch) |
+| `SPACESHIP_GIT_STATUS_ASSUME_UNCHANGED` | `⤒` | Indicator for the presence of an `--assume-unchanged` file |
+| `SPACESHIP_GIT_STATUS_SKIP_WORKTREE` | `↧` | Indicator for the presence of a `--skip-worktree` file |
 
 ### Mercurial (`hg`)
 

--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -20,23 +20,28 @@ SPACESHIP_GIT_STATUS_UNMERGED="${SPACESHIP_GIT_STATUS_UNMERGED="="}"
 SPACESHIP_GIT_STATUS_AHEAD="${SPACESHIP_GIT_STATUS_AHEAD="⇡"}"
 SPACESHIP_GIT_STATUS_BEHIND="${SPACESHIP_GIT_STATUS_BEHIND="⇣"}"
 SPACESHIP_GIT_STATUS_DIVERGED="${SPACESHIP_GIT_STATUS_DIVERGED="⇕"}"
+SPACESHIP_GIT_STATUS_ASSUME_UNCHANGED="${SPACESHIP_GIT_STATUS_ASSUME_UNCHANGED="⤒"}"
+SPACESHIP_GIT_STATUS_SKIP_WORKTREE="${SPACESHIP_GIT_STATUS_SKIP_WORKTREE="↧"}"
 
 # ------------------------------------------------------------------------------
 # Section
 # ------------------------------------------------------------------------------
 
 # We used to depend on OMZ git library,
-# But it doesn't handle many of the status indicator combinations.
-# Also, It's hard to maintain external dependency.
+# but it doesn't handle many of the status indicator combinations
+# or index indicators.
+# Also, it's hard to maintain external dependency.
 # See PR #147 at https://git.io/vQkkB
 # See git help status to know more about status formats
+# See git help update-index to know more about index formats
 spaceship_git_status() {
   [[ $SPACESHIP_GIT_STATUS_SHOW == false ]] && return
 
   spaceship::is_git || return
 
-  local INDEX git_status=""
+  local FILES INDEX git_status=""
 
+  FILES=$(command git ls-files -v $(git rev-parse --show-toplevel))
   INDEX=$(command git status --porcelain -b 2> /dev/null)
 
   # Check for untracked files
@@ -105,6 +110,16 @@ spaceship_git_status() {
   else
     [[ "$is_ahead" == true ]] && git_status="$SPACESHIP_GIT_STATUS_AHEAD$git_status"
     [[ "$is_behind" == true ]] && git_status="$SPACESHIP_GIT_STATUS_BEHIND$git_status"
+  fi
+
+  # Check whether any file has the --assume-unchanged bit set
+  if $(echo "$FILES" | grep '^[[:lower:]]' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_ASSUME_UNCHANGED$git_status"
+  fi
+
+  # Check whether any file has the --skip-worktree bit set
+  if $(echo "$FILES" | grep '^[sS]' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_SKIP_WORKTREE$git_status"
   fi
 
   if [[ -n $git_status ]]; then


### PR DESCRIPTION
Finally, the Spaceship v3 version of #207! Like that PR, it adds two git indicators:

- One which appears if any files are marked `--assumed-unchanged`
- One which appears if any files are marked `--skip-worktree`

In the previous PR, we discussed whether this should be its own section or rolled into the `git status` section, and whether there are better default symbols.

Including it in the git status section feels a little weird to me because this info isn't part of the actual `git-status`. But I agree the indicators should display next to the other git indicators, so I guess putting it in the git status section is the way to go. I considered naming the new variables `SPACESHIP_GIT_INDEX_ASSUME_UNCHANGED` and `SPACESHIP_GIT_INDEX_SKIP_WORKTREE`, but decided it's more important for the variable names to match the file name than for them to match the git command.

Happy to change the default symbols if there's something you prefer

Wonder what you think about renaming `INDEX` to `STATUS` (in `git_status.zsh` and I guess also in `hg_status.zsh`), and `FILES` to `INDEX` (in `git_status.zsh`)?