### PR TITLE
RFC: Use sum(available_mAh)/sum(total_mAh) as battery percentage in presence of 2 batteries (acpi -b only).

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -60,7 +60,7 @@ spaceship_battery() {
     # Return if no battery
     [[ -z $battery_data ]] && return
 
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+    battery_percent="$( echo $battery_data | awk '{SUM += $4; n++} END {print SUM / n}' )"
     battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
   else
     return

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -55,13 +55,13 @@ spaceship_battery() {
     battery_percent="$( echo $battery_data | grep percentage | awk '{print $2}' )"
     battery_status="$( echo $battery_data | grep state | awk '{print $2}' )"
   elif spaceship::exists acpi; then
-    battery_data=$(acpi -b)
+    battery_data=$(acpi -ib)
 
     # Return if no battery
     [[ -z $battery_data ]] && return
 
-    battery_percent="$( echo $battery_data | awk '{SUM += $4; n++} END {print SUM / n}' )"
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+    battery_percent="$( echo $battery_data | awk '(NR % 2){ perc=$4/100 } !(NR % 2) { availmAh += perc * $10; totalmAh += $10 } END { printf "%.0f", (availmAh / totalmAh)*100 }' )"
+    battery_status="$( echo $battery_data | awk '(NR % 2){ print tolower($3) }' | tr -d '%[,;' | awk '{ s=$1 } (s=="charging") { status=s } (s=="discharging") { status=s } END { print status }' )"
   else
     return
   fi


### PR DESCRIPTION
I don't think this PR is ready to merge, mostly because this only fixes it in my own personal use case, which is when the acpi -b command is being used.  But I wanted to provide this as a guidelines for the problem outlined in #245.

#### Description

Count the batteries, sum the percentage and report average percentage to the battery module in the acpi -b branch of the battery section.

