### PR TITLE
Add support for external configuration file

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,6 +1,9 @@
 ## Options
 
-You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme.
+You have ability to customize or disable specific elements of Spaceship. All options could be overridden in your `.zshrc` file (must be **after** the theme) or you could use an external configuration file. Spaceship-prompt will look for the following files in said order:
+- `$HOME/.spaceship-promptrc`
+- `$XDG_CONFIG_HOME/spaceship-prompt/config`, if $XDG_CONFIG_HOME is not set then defaults to $HOME/.config
+- `$XDG_CONFIG_DIRS/spaceship-prompt/config`
 
 Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/zsh#Colors) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
 
@@ -80,7 +83,7 @@ This group of options defines a behaviour of prompt and standard parameters for 
 
 ### Time (`time`)
 
-Disabled by default. Set `SPACESHIP_TIME_SHOW` to `true` in your `.zshrc`, if you need to show time stamps.
+Disabled by default. Set `SPACESHIP_TIME_SHOW` to `true` in your `.zshrc` or configuration file, if you need to show time stamps.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
@@ -529,7 +532,7 @@ This section show only when there are active jobs in the background.
 
 ### Exit code (`exit_code`)
 
-Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, if you need to show exit code of last command.
+Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc` or configuration file, if you need to show exit code of last command.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -35,8 +35,28 @@ fi
 
 # ------------------------------------------------------------------------------
 # CONFIGURATION
-# The default configuration that can be overridden in .zshrc
+# The default configuration that can be overridden in .zshrc or in local
+# configuration file
 # ------------------------------------------------------------------------------
+
+# Load local rc file if available, home dir first then basedir-spec $XDG_CONFIG_HOME
+local configfile
+if [[ -f "$HOME/.spaceship-promptrc" ]]; then
+  configfile="$HOME/.spaceship-promptrc"
+else
+  local dir
+  local dirs="${XDG_CONFIG_HOME:-"$HOME/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+  dirs=("${(@s/:/)dirs}")
+  for dir in $dirs; do
+    if [[ -f "$dir/spaceship-prompt/config" ]]; then
+      configfile="$dir/spaceship-prompt/config"
+      break
+    fi
+  done
+fi
+if [[ -n "$configfile" ]]; then
+    source "$configfile"
+fi
 
 if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
   SPACESHIP_PROMPT_ORDER=(


### PR DESCRIPTION
#### Description

Added support to override options using external configuration file.

Instead of using .zshrc when overriding options you can use a external configuration file. If file `$HOME/.spaceship-promptrc` is present it will be sourced. If not found, [XDG Base Directories](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) will be used to search and source configuration file if found.

Will load the following files in said order. First file found will be sourced. 
1. `$HOME/.spaceship-promptrc`
1. `$XDG_CONFIG_HOME/spaceship-prompt/config`, if $XDG_CONFIG_HOME is not set then defaults to $HOME/.config
1. `$XDG_CONFIG_DIRS/spaceship-prompt/config`
