### PR TITLE
Adding Fossil SCM support to spaceship prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ makepkg -si
 If you have problems with approches above, follow these instructions:
 
 * Clone this repo `git clone https://github.com/denysdovhan/spaceship-prompt.git`
-* Symlink `spaceship.zsh` to somewhere in [`$fpath`](http://www.refining-linux.org/archives/46/ZSH-Gem-12-Autoloading-functions/) as `prompt_spaceship_setup`.
+* Symlink `spaceship.zsh` to somewhere in [`$fpath`](https://www.refining-linux.org/archives/46-ZSH-Gem-12-Autoloading-functions.html) as `prompt_spaceship_setup`.
 * Initialize prompt system and choose `spaceship`.
 
 #### Example

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -37,6 +37,13 @@ spaceship::is_hg() {
   [[ -n "$root" ]] &>/dev/null
 }
 
+# Check if the current directory is in a Fossil repository.
+# USAGE:
+#   spaceship::is_fossil
+spaceship::is_fossil() {
+  command fossil ls &>/dev/null
+}
+
 # Print message backward compatibility warning
 # USAGE:
 #  spaceship::deprecated <deprecated> [message]

--- a/sections/fossil.zsh
+++ b/sections/fossil.zsh
@@ -1,0 +1,40 @@
+#
+# Fossil
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_FOSSIL_SHOW="${SPACESHIP_FOSSIL_SHOW=true}"
+SPACESHIP_FOSSIL_PREFIX="${SPACESHIP_FOSSIL_PREFIX="on "}"
+SPACESHIP_FOSSIL_SUFFIX="${SPACESHIP_FOSSIL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_FOSSIL_SYMBOL="${SPACESHIP_FOSSIL_SYMBOL="🝤 "}"
+
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/fossil_branch.zsh"
+source "$SPACESHIP_ROOT/sections/fossil_status.zsh"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show both fossil branch and fossil status:
+#   spaceship_fossil_branch
+#   spaceship_fossil_status
+spaceship_fossil() {
+  [[ $SPACESHIP_FOSSIL_SHOW == false ]] && return
+
+  local fossil_branch="$(spaceship_fossil_branch)" fossil_status="$(spaceship_fossil_status)"
+
+  [[ -z $fossil_branch ]] && return
+
+  spaceship::section \
+    'white' \
+    "$SPACESHIP_FOSSIL_PREFIX" \
+    "${fossil_branch}${fossil_status}" \
+    "$SPACESHIP_FOSSIL_SUFFIX"
+}

--- a/sections/fossil_branch.zsh
+++ b/sections/fossil_branch.zsh
@@ -1,0 +1,29 @@
+#
+# Fossil branch
+#
+# Show current Fossil branch
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_FOSSIL_BRANCH_SHOW="${SPACESHIP_FOSSIL_BRANCH_SHOW=true}"
+SPACESHIP_FOSSIL_BRANCH_PREFIX="${SPACESHIP_FOSSIL_BRANCH_PREFIX="$SPACESHIP_FOSSIL_SYMBOL"}"
+SPACESHIP_FOSSIL_BRANCH_SUFFIX="${SPACESHIP_FOSSIL_BRANCH_SUFFIX=""}"
+SPACESHIP_FOSSIL_BRANCH_COLOR="${SPACESHIP_FOSSIL_BRANCH_COLOR="magenta"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_fossil_branch() {
+  [[ $SPACESHIP_FOSSIL_BRANCH_SHOW == false ]] && return
+
+  spaceship::is_fossil || return
+
+  local fossil_info=$(fossil branch | cut -f2 -d" ")
+
+  spaceship::section \
+    "$SPACESHIP_FOSSIL_BRANCH_COLOR" \
+    "$SPACESHIP_FOSSIL_BRANCH_PREFIX"$fossil_info"$SPACESHIP_FOSSIL_BRANCH_SUFFIX"
+}

--- a/sections/fossil_status.zsh
+++ b/sections/fossil_status.zsh
@@ -1,0 +1,51 @@
+#
+# Fossil status
+#
+# Show Fossil status
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_FOSSIL_STATUS_SHOW="${SPACESHIP_FOSSIL_STATUS_SHOW=true}"
+SPACESHIP_FOSSIL_STATUS_PREFIX="${SPACESHIP_FOSSIL_STATUS_PREFIX=" ["}"
+SPACESHIP_FOSSIL_STATUS_SUFFIX="${SPACESHIP_FOSSIL_STATUS_SUFFIX="]"}"
+SPACESHIP_FOSSIL_STATUS_COLOR="${SPACESHIP_FOSSIL_STATUS_COLOR="red"}"
+SPACESHIP_FOSSIL_STATUS_UNTRACKED="${SPACESHIP_FOSSIL_STATUS_UNTRACKED="?"}"
+SPACESHIP_FOSSIL_STATUS_ADDED="${SPACESHIP_FOSSIL_STATUS_ADDED="+"}"
+SPACESHIP_FOSSIL_STATUS_MODIFIED="${SPACESHIP_FOSSIL_STATUD_MODIFIED="!"}"
+SPACESHIP_FOSSIL_STATUS_DELETED="${SPACESHIP_FOSSIL_STATUS_DELETED="✘"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Check if current dir is a fossil repo and show fossil status as indicators
+spaceship_fossil_status() {
+  [[ $SPACESHIP_FOSSIL_STATUS_SHOW == false ]] && return
+
+  spaceship::is_fossil || return
+
+  local INDEX=$(fossil changes --differ 2>/dev/null) fossil_status=""
+
+  # Indicators are suffixed instead of prefixed to each other to
+  # provide uniform view across git, mercurial and fossil indicators
+  if $(echo "$INDEX" | grep -E '^\EXTRA '  &> /dev/null); then
+    fossil_status="$SPACESHIP_FOSSIL_STATUS_UNTRACKED$fossil_status"
+  fi
+  if $(echo "$INDEX" | grep -E '^\ADDED ' &> /dev/null); then
+    fossil_status="$SPACESHIP_FOSSIL_STATUS_ADDED$fossil_status"
+  fi
+  if $(echo "$INDEX" | grep -E '^\EDITED ' &> /dev/null); then
+    fossil_status="$SPACESHIP_FOSSIL_STATUS_MODIFIED$fossil_status"
+  fi
+  if $(echo "$INDEX" | grep -E '^\DELETED ' &> /dev/null); then
+    fossil_status="$SPACESHIP_FOSSIL_STATUS_DELETED$fossil_status"
+  fi
+
+  if [[ -n $fossil_status ]]; then
+    spaceship::section \
+      "$SPACESHIP_FOSSIL_STATUS_COLOR" \
+      "$SPACESHIP_FOSSIL_STATUS_PREFIX"$fossil_status"$SPACESHIP_FOSSIL_STATUS_SUFFIX"
+  fi
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -46,6 +46,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     host          # Hostname section
     git           # Git section (git_branch + git_status)
     hg            # Mercurial section (hg_branch  + hg_status)
+    fossil        # Fossil section (fossil_branch  + fossil_status)
     package       # Package version
     node          # Node.js section
     ruby          # Ruby section


### PR DESCRIPTION
This pull request adds [Fossil SCM](https://www.fossil-scm.org/) to Spaceship Prompt. It's as light and fast as the others (mercurial and git), since it follows the same logic/structure.

I chose an alchemical symbol for putrefaction (somehow reminded me of fossils haha), thought about using t-rex or lizard symbol but they are colored. This can/should be improved by maybe finding a better symbol for it.

#### Screenshot

![Fossil Support in action here.](https://i.imgur.com/7bCGjBW.png)
