### PR TITLE
Fix xcode section checking swift and local being displayed globally

### DIFF
--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -25,10 +25,10 @@ spaceship_xcode() {
 
   local 'xcode_path'
 
-  if [[ $SPACESHIP_SWIFT_SHOW_GLOBAL == true ]] ; then
+  if [[ $SPACESHIP_XCODE_SHOW_GLOBAL == true ]] ; then
     xcode_path=$(xcenv version | sed 's/ .*//')
-  elif [[ $SPACESHIP_SWIFT_SHOW_LOCAL == true ]] ; then
-    if xcenv version | grep ".xcode-version" > /dev/null; then
+  elif [[ $SPACESHIP_XCODE_SHOW_LOCAL == true ]] ; then
+    if [[ `xcenv local 2>/dev/null` ]] ; then
       xcode_path=$(xcenv version | sed 's/ .*//')
     fi
   fi


### PR DESCRIPTION
#### Description

Fixes the xcode section from using defined swift variables. Further, it fixes the version being displayed regardless if the local variable was set or not. This is because the global version and local version are both set using a *.xcode-version, versus the swiftenv alternative has a ../version file and a .swift-version file for local folders. Issue on this is posted at #616.

#### Screenshot

Below is a screenshot displaying the variables from xcenv. Note that the global version here is set to false, and local is set to true. This PR address the issue.

![screenshot](https://camo.githubusercontent.com/f2c8d1580bf0ab1b1ef3c67d005647f75547dba2/68747470733a2f2f692e696d6775722e636f6d2f6d7768647654592e706e67)
