### PR TITLE
Added support for nix-shells

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -20,6 +20,7 @@ SPACESHIP_PROMPT_ORDER=(
   user          # Username section
   dir           # Current directory section
   host          # Hostname section
+  nix_shell     # Nix-shell package/environment information
   git           # Git section (git_branch + git_status)
   hg            # Mercurial section (hg_branch  + hg_status)
   package       # Package version
@@ -144,6 +145,15 @@ If current directory is write-protected or if current user has not enough rights
 | `SPACESHIP_DIR_COLOR` | `cyan` | Color of directory section |
 | `SPACESHIP_DIR_LOCK_SYMBOL` | ![·](https://user-images.githubusercontent.com/10276208/46248218-4af95d80-c434-11e8-8e25-595d792503f1.png) | The symbol displayed if directory is write-protected (requires powerline patched font) |
 | `SPACESHIP_DIR_LOCK_COLOR` | `red` | Color for the lock symbol |
+
+### Nix_shell (`nix_shell`)
+
+Shows the name of the current nix environment for easy distinction. If you initialized a nix-shell with the `-p` option it will show the packages that were passed during initialization.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_NIX_SHELL_SHOW` | true | Show nix_shell section|
+| `SPACESHIP_NIX_SHELL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after nix_shell section |
 
 ### Git (`git`)
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -153,7 +153,8 @@ Shows the name of the current nix environment for easy distinction. If you initi
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_NIX_SHELL_SHOW` | true | Show nix_shell section |
-| `SPACESHIP_NIX_SHELL_PREFIX` | "in " | Prefix before nix-shell. Defualt will change to with if nix-shell is initialized with `-p` |
+| `SPACESHIP_NIX_SHELL_PACKAGE_PREFIX` | "with " | Prefix before packages in nix-shell if initialized with `-p` |
+| `SPACESHIP_NIX_SHELL_NAMED_PREFIX` | "in " | Prefix before name of nix-shell if initialized with stdenv |
 | `SPACESHIP_NIX_SHELL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after nix_shell section |
 | `SPACESHIP_NIX_SHELL_SYMBOL` | "" | Character to be shown before name/packages |
 | `SPACESHIP_NIX_SHELL_COLOR` | green | Font color of section |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -152,8 +152,11 @@ Shows the name of the current nix environment for easy distinction. If you initi
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_NIX_SHELL_SHOW` | true | Show nix_shell section|
+| `SPACESHIP_NIX_SHELL_SHOW` | true | Show nix_shell section |
+| `SPACESHIP_NIX_SHELL_PREFIX` | "in " | Prefix before nix-shell. Defualt will change to with if nix-shell is initialized with `-p` |
 | `SPACESHIP_NIX_SHELL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after nix_shell section |
+| `SPACESHIP_NIX_SHELL_SYMBOL` | "" | Character to be shown before name/packages |
+| `SPACESHIP_NIX_SHELL_COLOR` | green | Font color of section |
 
 ### Git (`git`)
 

--- a/sections/nix_shell.zsh
+++ b/sections/nix_shell.zsh
@@ -21,28 +21,35 @@ SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFA
 
 ## nix-shell: currently running nix-shell
 spaceship_nix_shell() {
-    [[ $SPACESHIP_NIX_SHELL_SHOW == false ]] && return
+  [[ $SPACESHIP_NIX_SHELL_SHOW == false ]] && return
 
-    if [[ -n "$IN_NIX_SHELL" ]]; then
-	if [[ -n $NIX_SHELL_PACKAGES ]]; then
-	    local package_names=""
-	    local packages=($NIX_SHELL_PACKAGES)
-	    for package in $packages; do
-		package_names+="${package##*.}"
-	    done
-	    spaceship::section \
-		'yellow' \
-		"with " \
-		"$package_names" \
-		"$SPACESHIP_NIX_SHELL_SUFFIX"
-	else
-	    local cleanName=${name#interactive-}
-	    cleanName=${cleanName%-environment}
-	    spaceship::section \
-		'yellow' \
-		"in " \
-		"$cleanName" \
-		"$SPACESHIP_NIX_SHELL_SUFFIX"
-	fi
+  # Checks if shell is nix
+  if [[ -n "$IN_NIX_SHELL" ]]; then
+
+    # If initialized with `nix-shell -p [packages]`
+    if [[ -n $NIX_SHELL_PACKAGES ]]; then
+      local package_names=""
+      local packages=($NIX_SHELL_PACKAGES)
+
+      # Get all active packages
+      for package in $packages; do
+	package_names+="${package##*.}"
+      done
+      spaceship::section \
+	'yellow' \
+	"with " \
+	"$package_names" \
+	"$SPACESHIP_NIX_SHELL_SUFFIX"
+
+    # Else, get name property from default.nix
+    else
+      local cleanName=${name#interactive-}
+      cleanName=${cleanName%-environment}
+      spaceship::section \
+	'yellow' \
+	"in " \
+	"$cleanName" \
+	"$SPACESHIP_NIX_SHELL_SUFFIX"
     fi
+  fi
 }

--- a/sections/nix_shell.zsh
+++ b/sections/nix_shell.zsh
@@ -7,7 +7,10 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_NIX_SHELL_SHOW="${SPACESHIP_NIX_SHELL_SHOW=true}"
+SPACESHIP_NIX_SHELL_PREFIX="${SPACESHIP_NIX_SHELL_PREFIX="with "}"
 SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_NIX_SHELL_SYMBOL=""
+SPACESHIP_NIX_SHELL_COLOR="${SPACESHIP_NIX_SHELL_COLOR=green}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -19,37 +22,41 @@ SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFA
 # Heavily inspired by:
 # https://gist.github.com/chisui/0d12bd51a5fd8e6bb52e6e6a43d31d5e#file-agnoster-nix-zsh-theme-L201
 
-## nix-shell: currently running nix-shell
+# nix-shell: currently running nix-shell
 spaceship_nix_shell() {
   [[ $SPACESHIP_NIX_SHELL_SHOW == false ]] && return
 
-  # Checks if shell is nix
-  if [[ -n "$IN_NIX_SHELL" ]]; then
+  # Checks if shell is nix,
+  [[ -z $IN_NIX_SHELL ]] && return
 
-    # If initialized with `nix-shell -p [packages]`
-    if [[ -n $NIX_SHELL_PACKAGES ]]; then
-      local package_names=""
-      local packages=($NIX_SHELL_PACKAGES)
+  # If initialized with `nix-shell -p [packages]`
+  if [[ -n $NIX_SHELL_PACKAGES ]]; then
+    local package_names=""
+    local packages=($NIX_SHELL_PACKAGES)
 
-      # Get all active packages
-      for package in $packages; do
-	package_names+="${package##*.}"
-      done
-      spaceship::section \
-	'yellow' \
-	"with " \
-	"$package_names" \
-	"$SPACESHIP_NIX_SHELL_SUFFIX"
+    # Get all active packages
+    for package in $packages; do
+      package_names+="${package##*.}"
+    done
 
-    # Else, get name property from default.nix
-    else
-      local cleanName=${name#interactive-}
-      cleanName=${cleanName%-environment}
-      spaceship::section \
-	'yellow' \
-	"in " \
-	"$cleanName" \
-	"$SPACESHIP_NIX_SHELL_SUFFIX"
-    fi
+    spaceship::section \
+      '$SPACESHIP_NIX_SHELL_COLOR' \
+      "$SPACESHIP_NIX_SHELL_PREFIX" \
+      "${SPACESHIP_NIX_SHELL_SYMBOL}$package_names" \
+      "$SPACESHIP_NIX_SHELL_SUFFIX"
+
+  # Else, get name property from default.nix stdenvironment
+  else
+    local cleanName=${name#interactive-}
+    cleanName=${cleanName%-environment}
+
+    #change SPACESHIP_NIX_SHELL_PREFIX to in if default
+    [[ $SPACESHIP_NIX_SHELL_PREFIX == "with " ]] && SPACESHIP_NIX_SHELL_PREFIX="in "
+
+    spaceship::section \
+      '$SPACESHIP_NIX_SHELL_COLOR' \
+      "$SPACESHIP_NIX_SHELL_PREFIX" \
+      "${SPACESHIP_NIX_SHELL_SYMBOL}$cleanName" \
+      "$SPACESHIP_NIX_SHELL_SUFFIX"
   fi
 }

--- a/sections/nix_shell.zsh
+++ b/sections/nix_shell.zsh
@@ -1,0 +1,48 @@
+#
+# Nix-shell
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_NIX_SHELL_SHOW="${SPACESHIP_NIX_SHELL_SHOW=true}"
+SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# NOTE: needs https://github.com/chisui/zsh-nix-shell to show name and packages
+# from nix-shell environment
+
+# Heavily inspired by:
+# https://gist.github.com/chisui/0d12bd51a5fd8e6bb52e6e6a43d31d5e#file-agnoster-nix-zsh-theme-L201
+
+## nix-shell: currently running nix-shell
+spaceship_nix_shell() {
+    [[ $SPACESHIP_NIX_SHELL_SHOW == false ]] && return
+
+    if [[ -n "$IN_NIX_SHELL" ]]; then
+	if [[ -n $NIX_SHELL_PACKAGES ]]; then
+	    local package_names=""
+	    local packages=($NIX_SHELL_PACKAGES)
+	    for package in $packages; do
+		package_names+="${package##*.}"
+	    done
+	    spaceship::section \
+		'yellow' \
+		"with " \
+		"$package_names" \
+		"$SPACESHIP_NIX_SHELL_SUFFIX"
+	else
+	    local cleanName=${name#interactive-}
+	    cleanName=${cleanName%-environment}
+	    spaceship::section \
+		'yellow' \
+		"in " \
+		"$cleanName" \
+		"$SPACESHIP_NIX_SHELL_SUFFIX"
+	fi
+    fi
+}

--- a/sections/nix_shell.zsh
+++ b/sections/nix_shell.zsh
@@ -7,7 +7,8 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_NIX_SHELL_SHOW="${SPACESHIP_NIX_SHELL_SHOW=true}"
-SPACESHIP_NIX_SHELL_PREFIX="${SPACESHIP_NIX_SHELL_PREFIX="with "}"
+SPACESHIP_NIX_SHELL_NAMED_PREFIX="${SPACESHIP_NIX_SHELL_NAMED_PREFIX="in "}"
+SPACESHIP_NIX_SHELL_PACKAGE_PREFIX="${SPACESHIP_NIX_SHELL_PACKAGE_PREFIX="with "}"
 SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_NIX_SHELL_SYMBOL=""
 SPACESHIP_NIX_SHELL_COLOR="${SPACESHIP_NIX_SHELL_COLOR=green}"
@@ -41,7 +42,7 @@ spaceship_nix_shell() {
 
     spaceship::section \
       '$SPACESHIP_NIX_SHELL_COLOR' \
-      "$SPACESHIP_NIX_SHELL_PREFIX" \
+      "$SPACESHIP_NIX_SHELL_PACKAGE_PREFIX" \
       "${SPACESHIP_NIX_SHELL_SYMBOL}$package_names" \
       "$SPACESHIP_NIX_SHELL_SUFFIX"
 
@@ -50,12 +51,9 @@ spaceship_nix_shell() {
     local cleanName=${name#interactive-}
     cleanName=${cleanName%-environment}
 
-    #change SPACESHIP_NIX_SHELL_PREFIX to in if default
-    [[ $SPACESHIP_NIX_SHELL_PREFIX == "with " ]] && SPACESHIP_NIX_SHELL_PREFIX="in "
-
     spaceship::section \
       '$SPACESHIP_NIX_SHELL_COLOR' \
-      "$SPACESHIP_NIX_SHELL_PREFIX" \
+      "$SPACESHIP_NIX_SHELL_NAMED_PREFIX" \
       "${SPACESHIP_NIX_SHELL_SYMBOL}$cleanName" \
       "$SPACESHIP_NIX_SHELL_SUFFIX"
   fi

--- a/sections/nix_shell.zsh
+++ b/sections/nix_shell.zsh
@@ -11,7 +11,7 @@ SPACESHIP_NIX_SHELL_NAMED_PREFIX="${SPACESHIP_NIX_SHELL_NAMED_PREFIX="in "}"
 SPACESHIP_NIX_SHELL_PACKAGE_PREFIX="${SPACESHIP_NIX_SHELL_PACKAGE_PREFIX="with "}"
 SPACESHIP_NIX_SHELL_SUFFIX="${SPACESHIP_NIX_SHELL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_NIX_SHELL_SYMBOL=""
-SPACESHIP_NIX_SHELL_COLOR="${SPACESHIP_NIX_SHELL_COLOR=green}"
+SPACESHIP_NIX_SHELL_COLOR="${SPACESHIP_NIX_SHELL_COLOR="green"}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -32,29 +32,31 @@ spaceship_nix_shell() {
 
   # If initialized with `nix-shell -p [packages]`
   if [[ -n $NIX_SHELL_PACKAGES ]]; then
-    local package_names=""
+    local packageNames=""
     local packages=($NIX_SHELL_PACKAGES)
 
     # Get all active packages
     for package in $packages; do
-      package_names+="${package##*.}"
+      packageNames+="${package}"
     done
 
-    spaceship::section \
-      '$SPACESHIP_NIX_SHELL_COLOR' \
-      "$SPACESHIP_NIX_SHELL_PACKAGE_PREFIX" \
-      "${SPACESHIP_NIX_SHELL_SYMBOL}$package_names" \
-      "$SPACESHIP_NIX_SHELL_SUFFIX"
+    # format output and set prefix
+    output="$packageNames"
+    prefix="$SPACESHIP_NIX_SHELL_PACKAGE_PREFIX"
 
   # Else, get name property from default.nix stdenvironment
   else
     local cleanName=${name#interactive-}
     cleanName=${cleanName%-environment}
 
-    spaceship::section \
-      '$SPACESHIP_NIX_SHELL_COLOR' \
-      "$SPACESHIP_NIX_SHELL_NAMED_PREFIX" \
-      "${SPACESHIP_NIX_SHELL_SYMBOL}$cleanName" \
-      "$SPACESHIP_NIX_SHELL_SUFFIX"
+    # format output and set prefix
+    output="$cleanName"
+    prefix="$SPACESHIP_NIX_SHELL_NAMED_PREFIX"
   fi
+
+  spaceship::section \
+    "$SPACESHIP_NIX_SHELL_COLOR" \
+    "$prefix" \
+    "$output" \
+    "$SPACESHIP_NIX_SHELL_SUFFIX"
 }

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -44,6 +44,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     user          # Username section
     dir           # Current directory section
     host          # Hostname section
+    nix_shell     # Nix-shell
     git           # Git section (git_branch + git_status)
     hg            # Mercurial section (hg_branch  + hg_status)
     package       # Package version

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -44,7 +44,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     user          # Username section
     dir           # Current directory section
     host          # Hostname section
-    nix_shell     # Nix-shell
+    nix_shell     # Nix-shell package/environment information
     git           # Git section (git_branch + git_status)
     hg            # Mercurial section (hg_branch  + hg_status)
     package       # Package version


### PR DESCRIPTION
#### Description

Added support for the [nix-package manager](https://github.com/NixOS/nixpkgs), so it shows information about the current nix-shell. 

#### Screenshot

With `name = "spaceship-development";` in default.nix
![With `name = "spaceship-development";` in default.nix](https://i.imgur.com/Qd8vEOw.png)
When initialized with `nix-shell -p sfml gcc`
![When initialized with `nix-shell -p sfml gcc`](https://i.imgur.com/GdU2gxJ.png)