### PR TITLE
Python package versioning using pkg_resources.

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -225,12 +225,13 @@ Mercurial status indicators is shown only when you have dirty repository.
 
 ### Package version (`package`)
 
-> Works for [npm](https://www.npmjs.com/) and [cargo](https://crates.io/) at the moment. Please, help us improve this section!
+> Works for [npm](https://www.npmjs.com/), [cargo](https://crates.io/) and [python](https://www.python.org/) at the moment. Please, help us improve this section!
 
 Package version is shown when repository is a package.
 
 * **npm** — `npm` package contains a `package.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
 * **cargo** — `cargo` package contains a `Cargo.toml` file. Currently, we use `cargo pkgid`, it depends on `Cargo.lock`. So if package version isn't shown, you may need to run some command like `cargo build` which can generate `Cargo.lock` file.
+* **python** — `python` package contains a `setup.py` or `pyproject.toml` file (either in current dir, or git repo root). Currently, we use [pkg_resources](https://setuptools.readthedocs.io/en/latest/pkg_resources.html) to figure out the package version by package name. The package name is defined using either the [basename](https://docs.python.org/2/library/os.path.html#os.path.basename) of the git repository root directory (in case the current directory is inside a git repo) or the [basename](https://docs.python.org/2/library/os.path.html#os.path.basename) of the current directory.
 
 > **Note:** This is the version of the package you are working on, not the version of package manager itself.
 

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -5,6 +5,7 @@
 # These package managers supported:
 #   * NPM
 #   * Cargo
+#   * Python versioning
 
 # ------------------------------------------------------------------------------
 # Configuration
@@ -42,6 +43,53 @@ spaceship_package() {
     # https://github.com/denysdovhan/spaceship-prompt/pull/617
     local pkgid=$(cargo pkgid 2>&1)
     echo $pkgid | grep -q "error:" || package_version=${pkgid##*\#}
+  fi
+
+  # We only need to try python if no package version has been found yet
+  if [[ -z $package_version ||
+          "$package_version" == "null" ||
+          "$package_version" == "undefined" ]] &&
+          spaceship::exists python; then
+    # The modern way of verifying python package version is using pkg_resources
+    # The docs for pkg_resources can be found at:
+    # https://setuptools.readthedocs.io/en/latest/pkg_resources.html
+    # 
+    # spaceship will try to get your package version using the current directory name or git root.
+    # If the package is not found, it will not show any version.
+    local package_name="os.path.abspath(os.curdir)"
+    local package_root="."
+    local should_find_package=true
+
+    # If we are in a git repo, we should use the basename of the root of the repo
+    if spaceship::exists git && 
+              [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == "true" ]] ; then
+      package_root=$(git rev-parse --show-toplevel 2> /dev/null)
+      package_name="\\\"$package_root\\\""
+      # Even if we are in a git repo, we still need to have either setup.py or pyproject.toml
+      # Otherwise skip finding a package.
+      if [[ ! -f "$package_root/setup.py" ]] && [[ ! -f "$package_root/pyproject.toml" ]]; then
+        should_find_package=false
+      fi
+    else
+      # Otherwise if the current directory has either setup.py or pyproject.toml,
+      # use that, otherwise just skip finding a package.
+      if [[ ! -f "setup.py" ]] && [[ ! -f "pyproject.toml" ]]; then
+        should_find_package=false
+      fi
+    fi
+
+    # If our conditions have been met, find the package version
+    if [[ should_find_package ]]; then
+      local code="exec(\"import pkg_resources\nimport os\n"
+      code+="try:\n"
+      code+="    package_name = os.path.basename($package_name)\n"
+      code+="    print(pkg_resources.get_distribution(package_name).version)\n"
+      code+="except (pkg_resources.DistributionNotFound, pkg_resources.RequirementParseError):\n"
+      code+="    print(\\\"error: failed to import package\\\")\")"
+
+      local pkgid=$(cd $package_root && python -c "$code")
+      echo $pkgid | grep -q "error:" || package_version=${pkgid##*\#}
+    fi
   fi
 
   [[ -z $package_version || "$package_version" == "null" || "$package_version" == "undefined" ]] && return


### PR DESCRIPTION
#### Description
The package versioning for python now looks for two things:

* Are we in a git repo?
    * If `yes`, then is there a `setup.py` or `pyproject.toml` file at the root of the repo?;
    * If `no`, is there a `setup.py` or `pyproject.toml` file in the current directory?

If all the above evaluates to `true`, we use the `os.path.basename` of the directory where we found either `setup.py` or `pyproject.toml` to determine the package name.

After that it's just calling `pkg_resources` to get the package version.

#### Screenshot

The screenshot belows shows that it behaves as expected. In directories where neither file can be found it does not show any versions. When inside a git repo and `setup.py` or `pyproject.toml` are found in the root of the git repo, anywhere in the repo, the package is displayed.

![screenshot](https://i.imgur.com/F0roc2G.jpg)

#### Considerations

This PR allows python package to look inside a git repo root path. I believe this should be the case as well for npm and cargo. If that's the case I'd be more than happy to refactor `package.zsh` further in another PR.