### PR TITLE
Fix user not changing color when using su

### DIFF
--- a/sections/user.zsh
+++ b/sections/user.zsh
@@ -35,7 +35,7 @@ spaceship_user() {
   then
     local 'user_color'
 
-    if [[ $USER == 'root' ]]; then
+    if [[ $UID == 0 ]]; then
       user_color=$SPACESHIP_USER_COLOR_ROOT
     else
       user_color="$SPACESHIP_USER_COLOR"


### PR DESCRIPTION
#### Description

When switching to `root` using `su`, `root` is displayed in the normal user color.

This is because the color change is based on the condition `$USER == 'root'`, but when using `su` with no parameters, the value of `$USER` is not updated.

This can be fixed by basing the color change on `$UID == 0` instead, which, to my knowledge, should always be true for `root`.

#### Screenshot

**Before:**
![before](https://user-images.githubusercontent.com/2002883/56466159-e991df80-63c1-11e9-98a6-516c007b64ec.png)
**After:**
![after](https://user-images.githubusercontent.com/2002883/56466206-db908e80-63c2-11e9-9d3d-bc803441eae3.png)