### PR TITLE
Feat: TaskWarrior section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 - Optional exit-code of last command ([how to enable](./docs/Options.md#exit-code-exit_code)).
 - Optional time stamps 12/24hr in format ([how to enable](./docs/Options.md#time-time)).
 - Execution time of the last command if it exceeds the set threshold.
+- Number of tasks ready ([TaskWarrior](https://taskwarrior.org/docs/))
 
 Want more features? Please, [open an issue](https://github.com/denysdovhan/spaceship-prompt/issues/new/choose) or send pull request.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -17,6 +17,7 @@ The default order is:
 ```zsh
 SPACESHIP_PROMPT_ORDER=(
   time          # Time stamps section
+  task          # TaskWarrior section
   user          # Username section
   dir           # Current directory section
   host          # Hostname section
@@ -49,7 +50,6 @@ SPACESHIP_PROMPT_ORDER=(
   jobs          # Background jobs indicator
   exit_code     # Exit code section
   char          # Prompt character
-  task          # TaskWarrior section
 )
 ```
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -616,7 +616,7 @@ added to the prompt.
 | :------- | :-----: | ------- |
 | `SPACESHIP_TASK_SHOW` | `true` | Show number of tasks ready |
 | `SPACESHIP_TASK_SYMBOL` | `☑` | Character to be shown before task ready count |
-| `SPACESHIP_TASK_COLOR` | `white` | Color of TaskWarrior section |
+| `SPACESHIP_TASK_COLOR` | `magenta` | Color of TaskWarrior section |
 
 
 ## Need more?

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -49,6 +49,7 @@ SPACESHIP_PROMPT_ORDER=(
   jobs          # Background jobs indicator
   exit_code     # Exit code section
   char          # Prompt character
+  task_ready    # TaskWarrior section
 )
 ```
 
@@ -605,6 +606,15 @@ Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, 
 | `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
 | `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
 | `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |
+
+### TaskWarrior (`task_ready`)
+
+If the task command exists, the latest line of the `task ready` output will be
+added to the prompt.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_TASK_READY` | `true` | Show number of tasks ready |
 
 ## Need more?
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -49,7 +49,7 @@ SPACESHIP_PROMPT_ORDER=(
   jobs          # Background jobs indicator
   exit_code     # Exit code section
   char          # Prompt character
-  task_ready    # TaskWarrior section
+  task          # TaskWarrior section
 )
 ```
 
@@ -607,14 +607,17 @@ Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, 
 | `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
 | `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |
 
-### TaskWarrior (`task_ready`)
+### TaskWarrior (`task`)
 
 If the task command exists, the latest line of the `task ready` output will be
 added to the prompt.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_TASK_READY` | `true` | Show number of tasks ready |
+| `SPACESHIP_TASK_SHOW` | `true` | Show number of tasks ready |
+| `SPACESHIP_TASK_SYMBOL` | `☑` | Character to be shown before task ready count |
+| `SPACESHIP_TASK_COLOR` | `white` | Color of TaskWarrior section |
+
 
 ## Need more?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
   * [Vi-mode (vi_mode)](/docs/Options.md#vi-mode-vi_mode)
   * [Background Jobs (jobs)](/docs/Options.md#jobs-jobs)
   * [Exit code (exit_code)](/docs/Options.md#exit-code-exit_code)
+  * [TaskWarrior (task)](/docs/Options.md#taskwarrior-task)
 * [Contributing Guide](/CONTRIBUTING.md)
   * [Philosophy](/CONTRIBUTING.md#philosophy)
   * [Setup](/CONTRIBUTING.md#setup)

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -13,7 +13,7 @@
 
 SPACESHIP_TASK_SHOW="${SPACESHIP_TASK_SHOW=true}"
 SPACESHIP_TASK_SYMBOL="${SPACESHIP_TASK_SYMBOL="☑"}"
-SPACESHIP_TASK_COLOR="${SPACESHIP_TASK_COLOR="white"}"
+SPACESHIP_TASK_COLOR="${SPACESHIP_TASK_COLOR="magenta"}"
 
 # ------------------------------------------------------------------------------
 # Section

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -1,0 +1,39 @@
+#
+# TaskWarrior
+#
+# TaskWarrior manages your TODO list from the command line
+# Link: https://taskwarrior.org/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_TASK_SHOW="${SPACESHIP_TASK_SHOW=true}"
+SPACESHIP_TASK_SYMBOL="${SPACESHIP_TASK_SYMBOL="☑"}"
+SPACESHIP_TASK_COLOR="${SPACESHIP_TASK_COLOR="white"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show the number of tasks available in the task ready report
+spaceship_task() {
+  [[ $SPACESHIP_TASK_SHOW == false ]] && return
+
+  # Check if task command is available for execution
+  spaceship::exists task || return
+
+  local 'task_count'
+
+  if [[ $(task ready) -neq "No matches." ]]; then
+    task_count=$(task ready | tail -n1 | awk '{print $1}')
+  fi
+
+  # Exit section if variable is empty
+  [[ -z $task_count ]] && return
+
+  # Display foobar section
+  spaceship::section \
+    "$SPACESHIP_TASK_COLOR" \
+    "$SPACESHIP_TASK_SYMBOL$foobar_status" \
+  }

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -28,7 +28,7 @@ spaceship_task() {
 
   local 'task_count'
 
-  if [[ $(task ready) != "No matches." ]]; then
+  if [[ -n $(task ready 2>/dev/null) ]]; then
     task_count=$(task ready | tail -n1 | awk '{print $1}')
   fi
 
@@ -38,5 +38,5 @@ spaceship_task() {
   # Display task section
   spaceship::section \
     "$SPACESHIP_TASK_COLOR" \
-    "$SPACESHIP_TASK_SYMBOL $task_count" \
+    "$SPACESHIP_TASK_SYMBOL $task_count " \
   }

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -3,6 +3,9 @@
 #
 # TaskWarrior manages your TODO list from the command line
 # Link: https://taskwarrior.org/
+#
+# ready count inspired from: https://blog.djy.io/taskwarrior-where-have-you-been-all-my-life/
+#
 
 # ------------------------------------------------------------------------------
 # Configuration

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -28,7 +28,7 @@ spaceship_task() {
 
   local 'task_count'
 
-  if [[ $(task ready) -neq "No matches." ]]; then
+  if [[ $(task ready) != "No matches." ]]; then
     task_count=$(task ready | tail -n1 | awk '{print $1}')
   fi
 
@@ -38,5 +38,5 @@ spaceship_task() {
   # Display task section
   spaceship::section \
     "$SPACESHIP_TASK_COLOR" \
-    "$SPACESHIP_TASK_SYMBOL$task_count" \
+    "$SPACESHIP_TASK_SYMBOL $task_count" \
   }

--- a/sections/task.zsh
+++ b/sections/task.zsh
@@ -35,8 +35,8 @@ spaceship_task() {
   # Exit section if variable is empty
   [[ -z $task_count ]] && return
 
-  # Display foobar section
+  # Display task section
   spaceship::section \
     "$SPACESHIP_TASK_COLOR" \
-    "$SPACESHIP_TASK_SYMBOL$foobar_status" \
+    "$SPACESHIP_TASK_SYMBOL$task_count" \
   }

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -41,6 +41,7 @@ fi
 if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
   SPACESHIP_PROMPT_ORDER=(
     time          # Time stampts section
+    task          # TaskWarrior section
     user          # Username section
     dir           # Current directory section
     host          # Hostname section


### PR DESCRIPTION
**Status: COMPLETED**

#### Description

<!-- Describe your pull-request, what was changed and why… -->
After reading [this article](https://blog.djy.io/taskwarrior-where-have-you-been-all-my-life/), I also wanted to start using the `task ready` count TaskWarrior report to follow the Inbox Zero style.
This PR checks if the `task` tool exists, in which case it displays the remaining task count.

#### Tests
Tests are passing!

#### Screenshot

<details><summary>debugging</summary>
Currently having troubles testing this code.
When updating zgen to use my fork
```zsh
zgen load Fandekasp/spaceship-prompt spaceship feat/task_coun

SPACESHIP_ROOT=/home/dori/.zgen/Fandekasp/spaceship-prompt-feat/task_count
```

error log

```console
ls: cannot access '/home/dori/.zgen/denysdovhan/spaceship-prompt-master/sections/task.zsh': No such file or directory
Section 'task' have not been loaded.

'task' not foundin task_count on  feat/task_count [!] 
➜ echo $SPACESHIP_ROOT
/home/dori/.zgen/Fandekasp/spaceship-prompt-feat/task_count

```
Looks like the SPACESHIP_ROOT setting  is ignored


**Fixed** by adding `export SPACESHIP_ROOT="/home/dori/.zgen/Fandekasp/spaceship-prompt-feat/task_count"` on line 35 in `/home/dori/.zgen/Fandekasp/spaceship-prompt-feat/task_count/spaceship.zsh`
</details>

![](https://i.imgur.com/z4NymGe.png)