### PR TITLE
Added clarification to 'Options/Directory' section of documentation

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -130,7 +130,8 @@ Hostname is shown only when you're connected via SSH unless you change this beha
 
 ### Directory (`dir`)
 
-Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`. While you are in repository, it shows only root directory and folders inside it.
+Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`.
+If `SPACESHIP_DIR_TRUNC_REPO` is set to `true`, and you are in repository, it shows only root directory and folders inside it.
 If current directory is write-protected or if current user has not enough rights to write in it, a padlock (by default) is displayed as a suffix.
 
 | Variable | Default | Meaning |


### PR DESCRIPTION
#### Description

I added a part sentence to the _Directory_ section of the documentation, because it was confusing for me for the first time. I couldn't find this option in the table so I thought the prompt always cuts the path to the base repo dir.

I had to check the source code to understand it, and I think it will be more clear.

#### Screenshot

![image](https://user-images.githubusercontent.com/191887/62248197-d2fb1b80-b3e7-11e9-8561-de62dc49820b.png)

