### PR TITLE
feat: add git_commit with git commit short hash

### DIFF
--- a/sections/git.zsh
+++ b/sections/git.zsh
@@ -17,6 +17,7 @@ SPACESHIP_GIT_SYMBOL="${SPACESHIP_GIT_SYMBOL=" "}"
 
 source "$SPACESHIP_ROOT/sections/git_branch.zsh"
 source "$SPACESHIP_ROOT/sections/git_status.zsh"
+source "$SPACESHIP_ROOT/sections/git_commit.zsh"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -25,16 +26,18 @@ source "$SPACESHIP_ROOT/sections/git_status.zsh"
 # Show both git branch and git status:
 #   spaceship_git_branch
 #   spaceship_git_status
+#   spaceship_git_commit
 spaceship_git() {
   [[ $SPACESHIP_GIT_SHOW == false ]] && return
 
-  local git_branch="$(spaceship_git_branch)" git_status="$(spaceship_git_status)"
+  local git_branch="$(spaceship_git_branch)" git_status="$(spaceship_git_status)" git_commit="$(spaceship_git_commit)"
 
   [[ -z $git_branch ]] && return
 
   spaceship::section \
     'white' \
     "$SPACESHIP_GIT_PREFIX" \
-    "${git_branch}${git_status}" \
-    "$SPACESHIP_GIT_SUFFIX"
+    "${git_branch}${git_status}"${git_commit}"\
+    "$SPACESHIP_GIT_SUFFIX" \
+
 }

--- a/sections/git.zsh
+++ b/sections/git.zsh
@@ -37,7 +37,7 @@ spaceship_git() {
   spaceship::section \
     'white' \
     "$SPACESHIP_GIT_PREFIX" \
-    "${git_branch}${git_status}"${git_commit}"\
+    "${git_branch}${git_status}${git_commit}"\
     "$SPACESHIP_GIT_SUFFIX" \
 
 }

--- a/sections/git_commit.zsh
+++ b/sections/git_commit.zsh
@@ -1,0 +1,32 @@
+#
+# Git commit
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_GIT_COMMIT_SHOW="${SPACESHIP_GIT_COMMIT_SHOW=true}"
+SPACESHIP_GIT_COMMIT_PREFIX="${SPACESHIP_GIT_COMMIT_PREFIX=" #"}"
+SPACESHIP_GIT_COMMIT_SUFFIX="${SPACESHIP_GIT_COMMIT_SUFFIX=""}"
+SPACESHIP_GIT_COMMIT_COLOR="${SPACESHIP_GIT_COMMIT_COLOR="yellow"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_git_commit() {
+  [[ $SPACESHIP_GIT_COMMIT_SHOW == false ]] && return
+
+  spaceship::is_git || return
+
+  git_commit=$(command git rev-parse --short HEAD 2> /dev/null)
+
+  # Get commit short commit hash
+  if [[ -n $git_commit ]]; then
+    # Commit prefixes are colorized
+    spaceship::section \
+      "$SPACESHIP_GIT_COMMIT_COLOR" \
+      "$SPACESHIP_GIT_COMMIT_PREFIX$git_commit$SPACESHIP_GIT_COMMIT_SUFFIX"
+  fi
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -44,7 +44,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     user          # Username section
     dir           # Current directory section
     host          # Hostname section
-    git           # Git section (git_branch + git_status)
+    git           # Git section (git_branch + git_status + git_commit)
     hg            # Mercurial section (hg_branch  + hg_status)
     package       # Package version
     node          # Node.js section


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

- Add short git commit hash, prepending immediately next to  `git_status`.
- The display format git line is `"${git_branch}${git_status}${git_commit}"`.

#### Screenshot

<img width="302" alt="melvynkim@gmail com" src="https://user-images.githubusercontent.com/10689296/66280347-29169000-e86b-11e9-82c2-ac60ae9dae4c.png">
