### PR TITLE
Sections: look in a Spaceship config directory for section defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,22 +263,7 @@ spaceship_newsection() {
 }
 ```
 
-or in the `SPACESHIP_CONFIG_DIR`'s `sections` directory in files named after the section, for example
-
-```
-$SPACESHIP_CONFIG_DIR
-└── sections
-    └── newsection.zsh
-```
-
-```zsh
-cat $SPACESHIP_CONFIG_DIR/sections/newsection.zsh
-
-# --- snip ---
-spaceship_newsection() {
-# --- snip ---
-}
-```
+or in the Spaceship config directory's `sections` subdirectory (by default, `~/.config/spaceship/sections`). See the Options and API documentation for more information.
 
 **💡 Tip:** Take a look at popular option presets or share your own configuration on [Presets](https://github.com/denysdovhan/spaceship-prompt/wiki/Presets) wiki page.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,32 @@ Spaceship works well out of the box, but you can customize almost everything if 
 - [**Options**](./docs/Options.md) — Tweak section's behavior with tons of options.
 - [**API**](./docs/API.md) — Define a custom section that will do exactly what you want.
 
-You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme.
+You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme. Custom sections are defined in your `.zshrc`, for example
+
+```
+# .zshrc
+
+spaceship_newsection() {
+  # section definition
+}
+```
+
+or in the `SPACESHIP_CONFIG_DIR`'s `sections` directory in files named after the section, for example
+
+```
+$SPACESHIP_CONFIG_DIR
+└── sections
+    └── newsection.zsh
+```
+
+```zsh
+cat $SPACESHIP_CONFIG_DIR/sections/newsection.zsh
+
+# --- snip ---
+spaceship_newsection() {
+# --- snip ---
+}
+```
 
 **💡 Tip:** Take a look at popular option presets or share your own configuration on [Presets](https://github.com/denysdovhan/spaceship-prompt/wiki/Presets) wiki page.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -6,18 +6,6 @@ Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/z
 
 **Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
 
-### Configuration directory
-
-In addition to defining custom sections in your `.zshrc` file or in files you explicitly source into your `.zshrc` file, you can define custom sections in the  `SPACESHIP_CONFIG_DIR`'s `sections` directory.
-
-The default path is:
-
-```zsh
-SPACESHIP_CONFIG_DIR="${HOME}/.config/spaceship"
-```
-
-Each section must be in its own file, named after the section (e.g. `$SPACESHIP_CONFIG_DIR/sections/newsection.zsh`). See the [API docs](./API.md) for more information on how to define custom sections.
-
 ### Order
 
 You can specify the order of prompt section using `SPACESHIP_PROMPT_ORDER` option. Use Zsh array syntax to define your own prompt order.
@@ -65,6 +53,28 @@ SPACESHIP_PROMPT_ORDER=(
 ```
 
 You can also add items to the right prompt by specifying them in the `SPACESHIP_RPROMPT_ORDER` option. By default `SPACESHIP_RPROMPT_ORDER` is empty.
+
+## Sections
+
+### Custom
+
+Spaceship comes with the many prompt sections detailed below. If these options are not enough to do what you want, you can add custom sections. Define them directly in your `.zshrc` file, or in the `sections` directory in the  `SPACESHIP_CONFIG_DIR` directory.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_CONFIG_DIR` | `${HOME}/.config/spaceship` | The path to the Spaceship configuration directory |
+
+Sections in the configuration directory must be one per file, and the file's name must be the same as the section's. For example,
+
+```zsh
+# $SPACESHIP_CONFIG_DIR/sections/newsection.zsh
+# --- snip ---
+spaceship_newsection() {
+# --- snip ---
+}
+```
+
+See the [API documentation](./API.md) for information on how to write custom sections.
 
 ### Prompt
 
@@ -617,7 +627,3 @@ Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, 
 | `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
 | `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
 | `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |
-
-## Need more?
-
-If these options are not enough to do what you want, read more about Spaceship's API on [API page](./API.md) of the documentation.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,4 +1,4 @@
-## Options
+# Options
 
 You have ability to customize or disable specific elements of Spaceship. All options must be overridden in your `.zshrc` file **after** the theme.
 
@@ -6,7 +6,7 @@ Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/z
 
 **Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
 
-### Order
+## Order
 
 You can specify the order of prompt section using `SPACESHIP_PROMPT_ORDER` option. Use Zsh array syntax to define your own prompt order.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -6,6 +6,18 @@ Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/z
 
 **Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
 
+### Configuration directory
+
+In addition to defining custom sections in your `.zshrc` file or in files you explicitly source into your `.zshrc` file, you can define custom sections in the  `SPACESHIP_CONFIG_DIR`'s `sections` directory.
+
+The default path is:
+
+```zsh
+SPACESHIP_CONFIG_DIR="${HOME}/.config/spaceship"
+```
+
+Each section must be in its own file, named after the section (e.g. `$SPACESHIP_CONFIG_DIR/sections/newsection.zsh`). See the [API docs](./API.md) for more information on how to define custom sections.
+
 ### Order
 
 You can specify the order of prompt section using `SPACESHIP_PROMPT_ORDER` option. Use Zsh array syntax to define your own prompt order.

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -38,6 +38,10 @@ fi
 # The default configuration that can be overridden in .zshrc
 # ------------------------------------------------------------------------------
 
+# Config directory. Spaceship will check here for section definitions,
+# in sections/<section name>.zsh with entry point `spaceship_<section name>()`
+SPACESHIP_CONFIG_DIR="${SPACESHIP_CONFIG_DIR="${HOME}/.config/spaceship"}"
+
 if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
   SPACESHIP_PROMPT_ORDER=(
     time          # Time stampts section
@@ -112,7 +116,9 @@ source "$SPACESHIP_ROOT/lib/section.zsh"
 # ------------------------------------------------------------------------------
 
 for section in $(spaceship::union $SPACESHIP_PROMPT_ORDER $SPACESHIP_RPROMPT_ORDER); do
-  if [[ -f "$SPACESHIP_ROOT/sections/$section.zsh" ]]; then
+  if [[ -f "$SPACESHIP_CONFIG_DIR/sections/$section.zsh" ]]; then
+    source "$SPACESHIP_CONFIG_DIR/sections/$section.zsh"
+  elif [[ -f "$SPACESHIP_ROOT/sections/$section.zsh" ]]; then
     source "$SPACESHIP_ROOT/sections/$section.zsh"
   elif spaceship::defined "spaceship_$section"; then
     # Custom section is declared, nothing else to do


### PR DESCRIPTION
#### Description

Adds support for storing all custom sections in a single directory known to Spaceship. Two primary motivations:

- ergonomics: rather than manually importing section definitions into `.zshrc`, users can just save files to the directory Spaceship checks and be done with it
- section installation: this change makes it possible for section developers to write installation scripts which add section definitions without messing with the user's `.zshrc`. This could help cut down on the "add a section for X" PRs, as well as opening the door for more complex or bespoke sections that might not be appropriate for core

Default location follows the ~/.config convention. Puts sections in a `sections` subdirectory to leave room for anything else someone might want to put in the config directory in the future.

Added README documentation, following the same reasoning as in #762 that talking up the customizability can only make Spaceship sound even better, and that having more documentation will help users who aren't experienced with shell scripting.