### PR TITLE
Don't require aws-cli to exist when evaluating the AWS section

### DIFF
--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -22,9 +22,6 @@ SPACESHIP_AWS_COLOR="${SPACESHIP_AWS_COLOR="208"}"
 spaceship_aws() {
   [[ $SPACESHIP_AWS_SHOW == false ]] && return
 
-  # Check if the AWS-cli is installed
-  spaceship::exists aws || return
-
   # Is the current profile not the default profile
   [[ -z $AWS_PROFILE ]] || [[ "$AWS_PROFILE" == "default" ]] && return
 


### PR DESCRIPTION
#### Description

AWS_PROFILE is a cross-application standard and often used when
implementing software that uses AWS but does not rely on aws-cli,
eg. terraform, k8s or the AWS SDKs.
For projects that are built on top of those, it's very useful to
see the AWS_PROFILE section without having to install the aws-cli
first, especially since it serves no explicit purpose.

I also believe this is in line with
> **Work out of the box.** The prompt should work right after installation without any additional configuration. Install it and use it.
