### PR TITLE
Add configurable timeout for git status

### DIFF
--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -20,6 +20,8 @@ SPACESHIP_GIT_STATUS_UNMERGED="${SPACESHIP_GIT_STATUS_UNMERGED="="}"
 SPACESHIP_GIT_STATUS_AHEAD="${SPACESHIP_GIT_STATUS_AHEAD="⇡"}"
 SPACESHIP_GIT_STATUS_BEHIND="${SPACESHIP_GIT_STATUS_BEHIND="⇣"}"
 SPACESHIP_GIT_STATUS_DIVERGED="${SPACESHIP_GIT_STATUS_DIVERGED="⇕"}"
+SPACESHIP_GIT_STATUS_TIMEOUT_DELAY="${SPACESHIP_GIT_STATUS_TIMEOUT_DELAY="0"}"
+SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL="${SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL="⌛"}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -37,7 +39,14 @@ spaceship_git_status() {
 
   local INDEX git_status=""
 
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
+  INDEX=$(command timeout "$SPACESHIP_GIT_STATUS_TIMEOUT_DELAY" git status --porcelain -b 2> /dev/null)
+  if [[ $? -eq 124 ]]; then
+    # Status prefixes are colorized
+    spaceship::section \
+      "$SPACESHIP_GIT_STATUS_COLOR" \
+      "$SPACESHIP_GIT_STATUS_PREFIX$SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL$SPACESHIP_GIT_STATUS_SUFFIX"
+    return
+  fi
 
   # Check for untracked files
   if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then


### PR DESCRIPTION
#### Description

Adds
SPACESHIP_GIT_STATUS_TIMEOUT_DELAY="${SPACESHIP_GIT_STATUS_TIMEOUT_DELAY="0"}"
SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL="${SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL="⌛"}"

Default behavior is not changed.

User can set SPACESHIP_GIT_STATUS_TIMEOUT_DELAY to a duration acceptable
to gnu coreutils timeout and if the timeout expires, status will be
displayed as SPACESHIP_GIT_STATUS_TIMEOUT_SYMBOL instead of waiting to
calculate the status.

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

![image](https://user-images.githubusercontent.com/83846/76350742-464c0080-62da-11ea-8056-f8a21028d4a3.png)


#### Still To Be Done

I'm submitting this PR as a proof-of-concept to get any feedback.  I still need to:
- [ ] see whether the async rendering PR #697 obviates the need for timeouts.
- [ ] update the markdown docs
- [ ] run & possibly add a test to the npm tests
- [ ] make it more graceful when gnu coreutils timeout can't be found or enable the timeout command to be configured?  

Fix #795 