### PR TITLE
fix: dir wont render properly if node section is enabled

### DIFF
--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -35,7 +35,7 @@ spaceship_node() {
     node_version=$(nodenv version-name)
     [[ $node_version == "system" || $node_version == "node" ]] && return
   elif spaceship::exists node; then
-    node_version=$(node -v 2>/dev/null)
+    node_version=$(node -v 2>/dev/null | sed -e 's/\r//g')
   else
     return
   fi


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
This PR is to fix an issue I was having while using spaceship in oh-my-zsh on Swan(Cygwin).
For some reason the first character of the directory wasn't being drawn. I played around with enabling and disabling all the sections and I noticed it only happens in node directories.
I traced the issue to the output of `node --v`. Replacing `node --v` with `echo '123'` resolved the problem, which lead me to believe there was some hidden output of `node --v` on windows cygwin that was causing the issue. Using sed to remove any `\r` seems to fix the issue.

#### Screenshot
Before:
![image](https://user-images.githubusercontent.com/7690321/92583251-4dcf7080-f24f-11ea-9c26-b361a112c380.png)

After:
![image](https://user-images.githubusercontent.com/7690321/92583588-c3d3d780-f24f-11ea-8681-3e8524e3b12f.png)


<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
