### PR TITLE
Update ruby asdf version finder

### DIFF
--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -34,8 +34,8 @@ spaceship_ruby() {
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
-    # split output on space and return first element
-    ruby_version=${$(asdf current ruby)[1]}
+    # split output on space and return second element
+    ruby_version=${$(asdf current ruby)[2]}
   else
     return
   fi


### PR DESCRIPTION
asdf was updated to print version second

#### Description

`asdf current` command was updated an now prints the program name before the version number. This is apparent when `ruby` is printed in the prompt instead of the current version of ruby. I updated the ruby.zsh secion script to use the second part of the asdf output instead of the first

#### Screenshot

<img width="587" alt="Screen Shot 2020-10-08 at 9 41 05 AM" src="https://user-images.githubusercontent.com/1904364/95474381-a6775380-094a-11eb-8d34-39af76a791d6.png">

