### PR TITLE
README.md info about postscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npm install -g spaceship-prompt
 ```
 
 Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to your `$fpath` and set `prompt spaceship` in `.zshrc`. Just reload your terminal.
+Ensure that you have enabled post-scripts in npm by ```npm config set ignore-scripts false``` before starting installation.
 
 **💡 Tip:** Update Spaceship to new versions as you would any other package.
 


### PR DESCRIPTION
Postscripts should be allowed for npm install
ignore-scripts can be enabled later on

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
closes issue #871 
npm will not set prompt even after running ```npm install -g spaceship-prompt``` if postscripts are disabled.
<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
