### PR TITLE
Package: add support for package version from lerna.json

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -231,6 +231,7 @@ Mercurial status indicators is shown only when you have dirty repository.
 Package version is shown when repository is a package.
 
 * **npm** — `npm` package contains a `package.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section ([Why?](./Troubleshooting.md#why-is-my-prompt-slow))
+* **lerna** — `lerna` monorepo contains a `lerna.json` file. We use `jq`, `python` to parse package version for improving performance and `node` as a fallback. Install [jq](https://stedolan.github.io/jq/) for **improved performance** of this section (same reason as npm).
 * **cargo** — `cargo` package contains a `Cargo.toml` file. Currently, we use `cargo pkgid`, it depends on `Cargo.lock`. So if package version isn't shown, you may need to run some command like `cargo build` which can generate `Cargo.lock` file.
 
 > **Note:** This is the version of the package you are working on, not the version of package manager itself.

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -36,6 +36,27 @@ spaceship_package() {
     fi
   fi
 
+  # Show package version from lerna.json if is a lerna monorepo
+  # Note: lerna does not have to be installed in the global context
+  #       so checking for lerna binary does not make sense
+   if [[ -f lerna.json ]] && spaceship::exists npm; then
+   local 'lerna_package_version'
+    if spaceship::exists jq; then
+      lerna_package_version=$(jq -r '.version' lerna.json 2>/dev/null)
+    elif spaceship::exists python; then
+      lerna_package_version=$(python -c "import json; print(json.load(open('lerna.json'))['version'])" 2>/dev/null)
+    elif spaceship::exists node; then
+      lerna_package_version=$(node -p "require('./lerna.json').version" 2> /dev/null)
+    fi
+    if [[ ! -z "$lerna_package_version" || "$package_version" != "null" || "$package_version" != "undefined" ]]; then
+      if [[ "$lerna_package_version" == "independent" ]]; then
+        package_version="($lerna_package_version)"
+      else
+        package_version="${lerna_package_version}"
+      fi
+    fi
+  fi
+
   if [[ -f Cargo.toml ]] && spaceship::exists cargo; then
     # Handle missing field `version` in Cargo.toml.
     # `cargo pkgid` need Cargo.lock exists too. If it does't, do not show package version


### PR DESCRIPTION
## Description

<!-- Describe your pull-request, what was changed and why… -->

[Lerna monorepos](https://github.com/lerna/lerna) in "fixed/locked" mode store the root version number in `lerna.json` not `package.json`, therefore spaceship does not display the package version when at the root of the `lerna` monorepo.

This has been brought up a number of times in the `lerna` project descussion; specifically, to allow `lerna` to either use the `version` field in the root `package.json`, or mirror the lerna version number to `package.json`, however this was flatly turned down:
> The version field of the root manifest in a monorepo is irrelevant, as it should not itself be a published package.

_See lerna/lerna#1473 for more details on the discussion._

Also, since there is support `Cargo.toml`, it makes sense to add support for `lerna.json`.

_Tested and works perfectly_

_TODO for me: Think of a way to represent more `lerna` data in `spaceship-prompt`_

## Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->

No UI change, just detects the package version from `lerna.json` and falls back to `package.json` if `lerna.json` has no version number.

If `lerna` is in `independent` mode, `v(independent)` is displayed so the user knows that `lerna` will increment the version of individual packages on a `publish` command.
