### PR TITLE
Add Linux Screen section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 _book
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 node_modules
 _book
 

--- a/sections/screen.zsh
+++ b/sections/screen.zsh
@@ -34,6 +34,6 @@ spaceship_screen() {
   spaceship::section \
     "$SPACESHIP_SCREEN_COLOR" \
     "$SPACESHIP_SCREEN_PREFIX" \
-    "$SPACESHIP_SCREEN_SYMBOL${STY}" \
+    "$SPACESHIP_SCREEN_SYMBOL${STY#*.}" \
     "$SPACESHIP_SCREEN_SUFFIX"
 }

--- a/sections/screen.zsh
+++ b/sections/screen.zsh
@@ -1,0 +1,39 @@
+#
+# Screen
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_SCREEN_SHOW="${SPACESHIP_SCREEN_SHOW=true}"
+SPACESHIP_SCREEN_PREFIX="${SPACESHIP_SCREEN_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_SCREEN_SUFFIX="${SPACESHIP_SCREEN_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_SCREEN_SYMBOL="${SPACESHIP_SCREEN_SYMBOL="💻 "}"
+SPACESHIP_SCREEN_COLOR="${SPACESHIP_NODE_COLOR="870087"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_screen() {
+  [[ $SPACESHIP_SCREEN_SHOW == false ]] && return
+
+  # show screen only when we are in a screen session
+  # when we are in a screen session then:
+  # "$TERM" = "screen"
+  local 'screen_status'
+  if [[ "$TERM" == *"screen"* ]]; then
+  	screen_status="screen"
+  fi
+  [[ -z $screen_status ]] && return
+
+  # to print the word screen use below:
+#   "$SPACESHIP_SCREEN_SYMBOL$screen_status" \
+
+  spaceship::section \
+    "$SPACESHIP_SCREEN_COLOR" \
+    "$SPACESHIP_SCREEN_PREFIX" \
+    "$SPACESHIP_SCREEN_SYMBOL${STY}" \
+    "$SPACESHIP_SCREEN_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -42,6 +42,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
   SPACESHIP_PROMPT_ORDER=(
     time          # Time stampts section
     user          # Username section
+    screen        # Linux Screen session name
     dir           # Current directory section
     host          # Hostname section
     git           # Git section (git_branch + git_status)


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->
When using Linux screen, it is useful to know which screen session we are currently in. 
So, it helps to add a section in spaceship-prompt to show the screen session name. 

Credits for @sebastian-ruiz.
Closes #882 

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
<img width="252" alt="Screenshot 2021-02-03 at 14 48 43" src="https://user-images.githubusercontent.com/14846504/106709116-fd5a1480-662e-11eb-847b-3778e4a2c98c.png">

