### PR TITLE
add Flutter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Spaceship is a minimalistic, powerful and extremely customizable [Zsh][zsh-url] 
 - Current Ruby version, through rvm/rbenv/chruby/asdf (`💎`).
 - Current Elm version (`🌳`)
 - Current Elixir version, through kiex/exenv/elixir (`💧`).
+- Curretn Flutter version and branch (`💙`).
 - Current Swift version, through swiftenv (`🐦`).
 - Current Xcode version, through xenv (`🛠`).
 - Current Go version (`🐹`).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -297,6 +297,20 @@ Elixir section is shown only in directories that contain `mix.exs`, or any other
 | `SPACESHIP_ELIXIR_SYMBOL` | `💧·` | Character to be shown before Elixir version |
 | `SPACESHIP_ELIXIR_COLOR` | `magenta` | Color of Elixir section |
 
+### Flutter (`flutter`)
+
+Show current Flutter version and channel.   
+The Flutter section is displayed, by default, only in a Flutter context, ie. in directories that contain files/direcories associated with Flutter (`pubspec.yaml`|`*.(dart)`|`dart_tool`) or if in a Git repository that is a Flutter project  (`$git_root/pubspec.yaml`|`$git_root/lib/**/*.(dart)`|`$git_root/dart_tool`). To always show Flutter section set `SPACESHIP_FLUTTER_IN_CONTEXT_ONLY=false`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_FLUTTER_SHOW` | `true` | Show current Flutter version or not |
+| `SPACESHIP_FLUTTER_IN_CONTEXT_ONLY` | `true` | Show Flutter section only in a Flutter context |
+| `SPACESHIP_FLUTTER_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Flutter section |
+| `SPACESHIP_FLUTTER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Flutter section |
+| `SPACESHIP_FLUTTER_SYMBOL` | `💙 ` | Character to be shown before Flutter version |
+| `SPACESHIP_FLUTTER_COLOR` | `blue` | Color of Flutter section |
+
 ### Xcode (`xcode`)
 
 Shows current version of Xcode. Local version has more priority than global.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
   * [Ruby (ruby)](/docs/Options.md#ruby-ruby)
   * [Elm (elm)](/docs/Options.md#elm-elm)
   * [Elixir (elixir)](/docs/Options.md#elixir-elixir)
+  * [Flutter (flutter)](/docs/Options.md#flutter)
   * [Xcode (xcode)](/docs/Options.md#xcode-xcode)
   * [Swift (swift)](/docs/Options.md#swift-swift)
   * [Go (go)](/docs/Options.md#go-golang)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -57,6 +57,7 @@ SPACESHIP_PROMPT_ORDER=(
   node          # Node.js section
   ruby          # Ruby section
   elixir        # Elixir section
+  #flutter      # Flutter section
   # xcode       # Xcode section (Disabled)
   swift         # Swift section
   golang        # Go section

--- a/sections/flutter.zsh
+++ b/sections/flutter.zsh
@@ -1,0 +1,59 @@
+
+# Flutter
+
+# Flutter is an open-source UI software development kit
+# Link: https://flutter.dev/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+SPACESHIP_FLUTTER_SHOW="${SPACESHIP_FLUTTER_SHOW=true}"
+SPACESHIP_FLUTTER_IN_CONTEXT_ONLY="${SPACESHIP_FLUTTER_IN_CONTEXT_ONLY=true}"
+SPACESHIP_FLUTTER_PREFIX="${SPACESHIP_FLUTTER_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_FLUTTER_SUFFIX="${SPACESHIP_FLUTTER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_FLUTTER_SYMBOL="${SPACESHIP_FLUTTER_SYMBOL="💙 "}"
+SPACESHIP_FLUTTER_COLOR="${SPACESHIP_FLUTTER_COLOR="blue"}"
+
+# ------------------------------------------------------------------------------
+# Utils
+# ------------------------------------------------------------------------------
+
+spaceship::flutter::is_in_context() {
+    local is_in_context=false
+    
+    if [[ -f pubspec.yaml || -d dart_tool || -n *.dart(#qN^/) ]]; then
+      is_in_context=true
+    elif spaceship::is_git; then # flutter project in git repo?
+      local git_root=$(git rev-parse --show-toplevel)
+      if (cygpath --version) >/dev/null 2>/dev/null; then
+        git_root=$(cygpath -u $git_root)
+      fi
+      if [[ -f $git_root/pubspec.yaml || -d $git_root/dart_tool || -n $git_root/lib/**/*.dart(#qN^/) ]]; then
+        is_in_context=true
+      fi
+    fi
+
+    [[ $is_in_context == true ]]
+
+}
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+spaceship_flutter() {
+  [[ $SPACESHIP_FLUTTER_SHOW == false ]] && return
+
+  spaceship::exists flutter || return
+
+  [[ $SPACESHIP_FLUTTER_IN_CONTEXT_ONLY == true ]] && ! spaceship::flutter::is_in_context && return
+
+  local flutter_version_output=$(flutter --version --suppress-analytics | head -n 1)
+  local flutter_version=$(echo "$flutter_version_output" | awk '{print $2}')
+  local flutter_channel=$(echo "$flutter_version_output" | awk '{print $5}')
+
+  spaceship::section \
+    "$SPACESHIP_FLUTTER_COLOR" \
+    "$SPACESHIP_FLUTTER_PREFIX" \
+    "${SPACESHIP_FLUTTER_SYMBOL}v${flutter_version} [${flutter_channel}]" \
+    "$SPACESHIP_FLUTTER_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -53,6 +53,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     ruby          # Ruby section
     elm           # Elm section
     elixir        # Elixir section
+    flutter       # Flutter section
     xcode         # Xcode section
     swift         # Swift section
     golang        # Go section


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->
Added Flutter section 

Show current Flutter version and channel.
   
The Flutter section is displayed, by default, only in a Flutter context, ie. in directories that contain files/direcories associated with Flutter (`pubspec.yaml`|`*.(dart)`|`dart_tool`) or if in a Git repository that is a Flutter project  (`$git_root/pubspec.yaml`|`$git_root/lib/**/*.(dart)`|`$git_root/dart_tool`).   
To always show Flutter section set `SPACESHIP_FLUTTER_IN_CONTEXT_ONLY=false`.


#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
