### PR TITLE
fix: fix maven section bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
   release:
     name: Release
     needs: main
-    if: ${{ github.repository == 'spaceship-prompt/spaceship-prompt' && github.event_name == 'push'}}
+    if: ${{ github.repository == 'spaceship-prompt/spaceship-prompt' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/sections/maven.zsh
+++ b/sections/maven.zsh
@@ -49,7 +49,7 @@ spaceship::maven::find_maven_wrapper() {
 spaceship::maven::versions() {
   local maven_exe="$1" maven_version_output maven_version jvm_version
 
-  maven_version_output=$("$maven_exe" --version)
+  maven_version_output=$("$maven_exe" --version 2>/dev/null)
   maven_version=$(echo "$maven_version_output" | awk '{ if ($2 ~ /^Maven/) { print "v" $3 } }')
   jvm_version=$(echo "$maven_version_output" | awk '{ if ($1 ~ /^Java/) { print "v" substr($3, 1, length($3)-1) } }')
 


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

When git clones a Java repo which uses mvnw at first time, mvnw will use `wget`(if exists in PATH) to download maven-wrapper. `wget` will print log to stderr([see more](https://www.gnu.org/software/wget/manual/html_node/Logging-and-Input-File-Options.html)). 

```
~/GitHub
➜ git clone git@github.com:Runrioter/spring.git
Cloning into 'spring'...
remote: Enumerating objects: 40326, done.
remote: Counting objects: 100% (491/491), done.
remote: Compressing objects: 100% (213/213), done.
remote: Total 40326 (delta 285), reused 433 (delta 260), pack-reused 39835
Receiving objects: 100% (40326/40326), 14.51 MiB | 2.35 MiB/s, done.
Resolving deltas: 100% (28132/28132), done.

~/GitHub took 10s
➜ cd spring
--2021-06-08 19:11:13--  https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
正在解析主机 repo.maven.apache.org (repo.maven.apache.org)... 199.232.192.215, 199.232.196.215
正在连接 repo.maven.apache.org (repo.maven.apache.org)|199.232.192.215|:443... 已连接。
已发出 HTTP 请求，正在等待回应... 200 OK
长度：50710 (50K) [application/java-archive]
正在保存至: “/Users/x/GitHub/spring/.mvn/wrapper/maven-wrapper.jar”

/Users/x/GitHub/spring/.mvn/wrapper/maven-wrapper.j 100%[========================================================================================================================================>]  49.52K  --.-KB/s  用时 0.1s

2021-06-08 19:11:14 (347 KB/s) - 已保存 “/Users/x/GitHub/spring/.mvn/wrapper/maven-wrapper.jar” [50710/50710])

spring on  main via 𝑚 v3.8.1 via ☕️ v11.0.11
➜
```

<!-- Describe your pull-request, what was changed and why… -->

