### PR TITLE
Fix: Do not add a newline before prompt when terminal opens

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -150,7 +150,7 @@ spaceship_prompt() {
   # will be overridden by a different command execution - do not move this line!
   RETVAL=$?
 
-  # Should it add a new line before the prompt?
+  # Removes a new line before the prompt when terminal opens. See more at https://github.com/spaceship-prompt/spaceship-prompt/issues/977
   [[ $UID == 0 ]] && SPACESHIP_PROMPT_NEED_NEWLINE=true
   [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true && $SPACESHIP_PROMPT_NEED_NEWLINE == true ]] && echo -n "$NEWLINE"
   SPACESHIP_PROMPT_NEED_NEWLINE=true

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -150,10 +150,13 @@ spaceship_prompt() {
   # will be overridden by a different command execution - do not move this line!
   RETVAL=$?
 
-  # Removes a new line before the prompt when terminal opens. See more at https://github.com/spaceship-prompt/spaceship-prompt/issues/977
+  # Removes a new line before the prompt when terminal opens.
+  # Ref: https://github.com/spaceship-prompt/spaceship-prompt/issues/977
   [[ $UID == 0 ]] && SPACESHIP_PROMPT_NEED_NEWLINE=true
   [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true && $SPACESHIP_PROMPT_NEED_NEWLINE == true ]] && echo -n "$NEWLINE"
   SPACESHIP_PROMPT_NEED_NEWLINE=true
+  
+  # Compose prompt from the order
   spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER
 }
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -151,7 +151,9 @@ spaceship_prompt() {
   RETVAL=$?
 
   # Should it add a new line before the prompt?
-  [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true ]] && echo -n "$NEWLINE"
+  [[ $UID == 0 ]] && SPACESHIP_PROMPT_NEED_NEWLINE=true
+  [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true && $SPACESHIP_PROMPT_NEED_NEWLINE == true ]] && echo -n "$NEWLINE"
+  SPACESHIP_PROMPT_NEED_NEWLINE=true
   spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER
 }
 


### PR DESCRIPTION
Fixes #977
Hi @denysdovhan, how does this look?
Let me know if this needs any changes.
Thanks