### PR TITLE
Unalias grep for PHP version

### DIFF
--- a/sections/php.zsh
+++ b/sections/php.zsh
@@ -27,7 +27,7 @@ spaceship_php() {
 
   spaceship::exists php || return
 
-  local php_version=$(php -v 2>&1 | grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
+  local php_version=$(php -v 2>&1 | \grep --color=never -oe "^PHP\s*[0-9.]\+" | awk '{print $2}')
 
   spaceship::section \
     "$SPACESHIP_PHP_COLOR" \


### PR DESCRIPTION
#### Description

Similar to [#857](https://github.com/spaceship-prompt/spaceship-prompt/pull/857), unalias grep when getting PHP version.

#### Before change

```
src on  master via 🐘 vinput):1:PHP 
[I] ➜ 
```

#### After change

```
src on  master via 🐘 v8.0.8 
[I] ➜ 
```