### PR TITLE
Always show pyenv venv if one is active

### DIFF
--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -26,7 +26,8 @@ spaceship_pyenv() {
 
   local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
 
-  [[ $pyenv_status == system ]] && return
+  # Empty string can happen if .python-version points to non-existent venv
+  [[ $pyenv_status == "" || $pyenv_status == system ]] && return
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \

--- a/sections/pyenv.zsh
+++ b/sections/pyenv.zsh
@@ -22,12 +22,11 @@ SPACESHIP_PYENV_COLOR="${SPACESHIP_PYENV_COLOR="yellow"}"
 spaceship_pyenv() {
   [[ $SPACESHIP_PYENV_SHOW == false ]] && return
 
-  # Show pyenv python version only for Python-specific folders
-  [[ -n "$PYENV_VERSION" || -f .python-version || -f requirements.txt || -f pyproject.toml || -n *.py(#qN^/) ]] || return
-
   spaceship::exists pyenv || return # Do nothing if pyenv is not installed
 
   local pyenv_status=${$(pyenv version-name 2>/dev/null)//:/ }
+
+  [[ $pyenv_status == system ]] && return
 
   spaceship::section \
     "$SPACESHIP_PYENV_COLOR" \


### PR DESCRIPTION
#### Description

When a pyenv's virtual environment is active, it's still worth knowing it even if the folder you are currently in does not contain any Python-specific file. Sometimes, for example, you are in a `templates` folder that only contains `.html` files, but you're still working in a Python project and issuing a `pip install` command against the wrong environment could cause inconvenience.

When the current pyenv environment is `system`, this usually means just the system-default Python interpreter is being used, and in such cases I believe there's no need to show it since it's the same as there being no pyenv virtual environment active.