### PR TITLE
fix: maven 3.5.0 bug

### DIFF
--- a/sections/maven.zsh
+++ b/sections/maven.zsh
@@ -51,7 +51,7 @@ spaceship::maven::versions() {
 
   maven_version_output=$("$maven_exe" --version 2>/dev/null)
   maven_version=$(echo "$maven_version_output" | awk '{ if ($2 ~ /^Maven/) { print "v" $3 } }')
-  jvm_version=$(echo "$maven_version_output" | awk '{ if ($1 ~ /^Java/) { print "v" substr($3, 1, length($3)-1) } }')
+  jvm_version=$(echo "$maven_version_output" | awk '{ if ($0 ~ /^Java version/) { print "v" substr($3, 1, length($3)-1) } }')
 
   print maven "$maven_version" jvm "$jvm_version"
 }


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

As @heefan 's output:

```shell
Apache Maven 3.5.0 (ff8f5e7444045639af65f6095c62210b5713f426; 2017-04-04T03:39:06+08:00)
Maven home: /Users/x/.m2/wrapper/dists/apache-maven-3.5.0-bin/6ps54u5pnnbbpr6ds9rppcc7iv/apache-maven-3.5.0
Java version: 1.8.0_281, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_281.jdk/Contents/Home/jre
Default locale: en_SG, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
```

There are two lines that contain `Java`.

And my terminal output: (not contains `Java home`)

```shell
➜ ./mvnw --version
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /Users/x/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3
Java version: 1.8.0_292, vendor: AdoptOpenJDK, runtime: /Users/swearwang/.sdkman/candidates/java/8.0.292.hs-adpt/jre
Default locale: zh_CN, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
```

So he got a bug.

Close #1052

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
