### PR TITLE
Prevent unintended output when `dotnet --version` fails

### DIFF
--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -30,7 +30,12 @@ spaceship_dotnet() {
 
   # dotnet-cli automatically handles SDK pinning (specified in a global.json file)
   # therefore, this already returns the expected version for the current directory
-  local dotnet_version=$(dotnet --version 2>/dev/null)
+  local dotnet_version # separate declaration so we have access to the exit code
+  dotnet_version=$(dotnet --version 2>/dev/null)
+
+  # `dotnet --version` exits with a non-zero exit code
+  # when the version defined in global.json is not installed.
+  [[ $? -eq 0 ]] || return
 
   spaceship::section \
     "$SPACESHIP_DOTNET_COLOR" \


### PR DESCRIPTION
#### Description

`dotnet --version` prints all available versions when the version specified in global.json is not installed. This causes the prompt to show this list in the version section.

I wasn't sure what to do when `dotnet --version` fails:
* Hide entire .NET section (this is the option I went with for no particular reason)
* Show .NET with no version

#### Screenshot

Before:
![Screenshot 2021-07-22 at 16 56 42](https://user-images.githubusercontent.com/4602612/126660911-a7c58d16-1c6f-490c-a88d-66f4f6598d87.png)
After:
![Screenshot 2021-07-22 at 16 57 29](https://user-images.githubusercontent.com/4602612/126661016-4cbde5e5-ec85-42f3-af0a-1eb29b45ad71.png)
