### PR TITLE
Add support for Cabal to Haskell section

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -375,15 +375,17 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 
 ### Haskell (`haskell`)
 
-Haskell section is shown only in directories that contain `stack.yaml` file.
+Haskell section is shown in directories that contain `*.cabal` or `stack.yaml`.
 
-| Variable                   |              Default               | Meaning                                                 |
-| :------------------------- | :--------------------------------: | ------------------------------------------------------- |
-| `SPACESHIP_HASKELL_SHOW`   |               `true`               | Shown current Haskell Tool Stack version or not         |
-| `SPACESHIP_HASKELL_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Haskell section                       |
-| `SPACESHIP_HASKELL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Haskell section                        |
-| `SPACESHIP_HASKELL_SYMBOL` |                `λ·`                | Character to be shown before Haskell Tool Stack version |
-| `SPACESHIP_HASKELL_COLOR`  |               `red`                | Color of Haskell section                                |
+| Variable                          | Default                            | Meaning                                                 |
+| :-------------------------        | :--------------------------------: | ------------------------------------------------------- |
+| `SPACESHIP_HASKELL_SHOW`          | `true`                             | Show current Haskell Tool Stack version or not          |
+| `SPACESHIP_HASKELL_PREFIX`        | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Haskell section                       |
+| `SPACESHIP_HASKELL_SUFFIX`        | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Haskell section                        |
+| `SPACESHIP_HASKELL_SYMBOL`        | `λ·`                               | Character to be shown before Haskell Tool Stack version |
+| `SPACESHIP_HASKELL_COLOR`         | `red`                              | Color of Haskell section                                |
+| `SPACESHIP_HASKELL_SUPPORT_CABAL` | `true`                             | Support Cabal based projects                            |
+| `SPACESHIP_HASKELL_SUPPORT_STACK` | `true`                             | Support Stack based projects                            |
 
 ### Julia (`julia`)
 

--- a/sections/haskell.zsh
+++ b/sections/haskell.zsh
@@ -1,5 +1,5 @@
 #
-# Haskell Stack
+# Haskell
 #
 # An advanced, purely functional programming language.
 # Link: https://www.haskell.org/
@@ -13,22 +13,29 @@ SPACESHIP_HASKELL_PREFIX="${SPACESHIP_HASKELL_PREFIX="$SPACESHIP_PROMPT_DEFAULT_
 SPACESHIP_HASKELL_SUFFIX="${SPACESHIP_HASKELL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_HASKELL_SYMBOL="${SPACESHIP_HASKELL_SYMBOL="λ "}"
 SPACESHIP_HASKELL_COLOR="${SPACESHIP_HASKELL_COLOR="red"}"
+SPACESHIP_HASKELL_SUPPORT_CABAL="${SPACESHIP_HASKELL_SUPPORT_CABAL=true}"
+SPACESHIP_HASKELL_SUPPORT_STACK="${SPACESHIP_HASKELL_SUPPORT_STACK=true}"
 
 # ------------------------------------------------------------------------------
 # Section
 # ------------------------------------------------------------------------------
 
-# Show current version of Haskell Tool Stack.
+# Show current version of Haskell compiler.
 spaceship_haskell() {
   [[ $SPACESHIP_HASKELL_SHOW == false ]] && return
 
-  # If there are stack files in current directory
-  [[ -f stack.yaml ]] || return
-
-  # The command is stack, so do not change this to haskell.
-  spaceship::exists stack || return
-
-  local haskell_version=$(stack ghc -- --numeric-version --no-install-ghc)
+  local haskell_version
+  if [[ ${SPACESHIP_HASKELL_SUPPORT_CABAL} == true &&
+          -n *.cabal(#qN) ]] &&
+       spaceship::exists cabal; then
+    haskell_version=$(ghc -- --numeric-version --no-install-ghc)
+  elif [[ ${SPACESHIP_HASKELL_SUPPORT_STACK} == true &&
+            -f stack.yaml ]] &&
+         spaceship::exists stack; then
+    haskell_version=$(stack ghc -- --numeric-version --no-install-ghc)
+  else
+    return
+  fi
 
   spaceship::section \
     "$SPACESHIP_HASKELL_COLOR" \


### PR DESCRIPTION
#### Description

There are two build tools in common use for Haskell, `stack` (already supported) and `cabal` (added in this changeset).

The change adds configuration options to control support for both tools.

#### Screenshot

There is no visible change to the section.