### PR TITLE
feat: track debian chroot through hostname

### DIFF
--- a/sections/host.zsh
+++ b/sections/host.zsh
@@ -21,7 +21,7 @@ SPACESHIP_HOST_COLOR_SSH="${SPACESHIP_HOST_COLOR_SSH="green"}"
 spaceship_host() {
   [[ $SPACESHIP_HOST_SHOW == false ]] && return
 
-  if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]]; then
+  if [[ $SPACESHIP_HOST_SHOW == 'always' ]] || [[ -n $SSH_CONNECTION ]] || [[ -n $debian_chroot ]]; then
     local host_color host
 
     # Determination of what color should be used
@@ -35,6 +35,10 @@ spaceship_host() {
       host="%M"
     else
       host="%m"
+    fi
+
+    if [[ -n $debian_chroot ]]; then
+        host="($debian_chroot)$host"
     fi
 
     spaceship::section \


### PR DESCRIPTION
#### Description

On Debian systems, chroots can be identified on the shell prompt.

When entering a "dev" chroot on a "mycomputer" system, then the prompt becomes "(dev)mycomputer".

With Spaceship Prompt, we're losing this information (and may run commands in an incorrect environment).

#### Screenshot

![image](https://user-images.githubusercontent.com/8590051/148692920-6dfa7edf-105d-41eb-bd23-413513f11508.png)