### PR TITLE
fix: set proper message if no account

### DIFF
--- a/sections/ibmcloud.zsh
+++ b/sections/ibmcloud.zsh
@@ -14,7 +14,7 @@
 SPACESHIP_IBMCLOUD_SHOW="${SPACESHIP_IBMCLOUD_SHOW=false}"
 SPACESHIP_IBMCLOUD_PREFIX="${SPACESHIP_IBMCLOUD_PREFIX="using "}"
 SPACESHIP_IBMCLOUD_SUFFIX="${SPACESHIP_IBMCLOUD_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
-SPACESHIP_IBMCLOUD_SYMBOL="${SPACESHIP_IBMCLOUD_SYMBOL="👔"}"
+SPACESHIP_IBMCLOUD_SYMBOL="${SPACESHIP_IBMCLOUD_SYMBOL="👔 "}"
 SPACESHIP_IBMCLOUD_COLOR="${SPACESHIP_IBMCLOUD_COLOR="039"}"
 
 # ------------------------------------------------------------------------------
@@ -31,11 +31,11 @@ spaceship_ibmcloud() {
 
     # If no account is targeted, the awk command will return "No", so we need to
     # check for that and set it to the full message manually.
-    [[ "No" == $ibmcloud_account ]] && local ibmcloud_account="No account targeted"
+    [[ "No" == $ibmcloud_account ]] && ibmcloud_account="No account targeted"
 
     spaceship::section \
         "$SPACESHIP_IBMCLOUD_COLOR" \
         "$SPACESHIP_IBMCLOUD_PREFIX" \
-        "$SPACESHIP_IBMCLOUD_SYMBOL $ibmcloud_account" \
+        "$SPACESHIP_IBMCLOUD_SYMBOL$ibmcloud_account" \
         "$SPACESHIP_IBMCLOUD_SUFFIX"
 }

--- a/sections/ibmcloud.zsh
+++ b/sections/ibmcloud.zsh
@@ -14,7 +14,7 @@
 SPACESHIP_IBMCLOUD_SHOW="${SPACESHIP_IBMCLOUD_SHOW=false}"
 SPACESHIP_IBMCLOUD_PREFIX="${SPACESHIP_IBMCLOUD_PREFIX="using "}"
 SPACESHIP_IBMCLOUD_SUFFIX="${SPACESHIP_IBMCLOUD_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
-SPACESHIP_IBMCLOUD_SYMBOL="${SPACESHIP_IBMCLOUD_SYMBOL="👔 "}"
+SPACESHIP_IBMCLOUD_SYMBOL="${SPACESHIP_IBMCLOUD_SYMBOL="👔"}"
 SPACESHIP_IBMCLOUD_COLOR="${SPACESHIP_IBMCLOUD_COLOR="039"}"
 
 # ------------------------------------------------------------------------------
@@ -29,9 +29,13 @@ spaceship_ibmcloud() {
     local ibmcloud_account=$(ibmcloud target | grep Account | awk '{print $2}')
     [[ -z $ibmcloud_account ]] && return
 
+    # If no account is targeted, the awk command will return "No", so we need to
+    # check for that and set it to the full message manually.
+    [[ "No" == $ibmcloud_account ]] && local ibmcloud_account="No account targeted"
+
     spaceship::section \
         "$SPACESHIP_IBMCLOUD_COLOR" \
         "$SPACESHIP_IBMCLOUD_PREFIX" \
-        "$SPACESHIP_IBMCLOUD_SYMBOL$ibmcloud_account" \
+        "$SPACESHIP_IBMCLOUD_SYMBOL $ibmcloud_account" \
         "$SPACESHIP_IBMCLOUD_SUFFIX"
 }


### PR DESCRIPTION
* If no account is targeted, the section is just gonna say "No" because
  of the simple awk command. This makes the message more meaning full.
