### PR TITLE
docs: Update Zim installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Set `ZSH_THEME="spaceship"` in your `.zshrc`.
 
 ### [zim]
 
-Add `zmodule spaceship-prompt/spaceship-prompt --name spaceship` to your `.zimrc` and run `zimfw install`.
+Add `zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules` to your `.zimrc` and run `zimfw install`.
 
 ### [antigen]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,7 +100,7 @@ Now that the requirements are satisfied, you can install Spaceship via any of th
 
 === "zim"
 
-    Add `zmodule spaceship-prompt/spaceship-prompt --name spaceship` to your `.zimrc` and run `zimfw install`.
+    Add `zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules` to your `.zimrc` and run `zimfw install`.
 
 === "antigen"
 

--- a/docs/getting-started.uk.md
+++ b/docs/getting-started.uk.md
@@ -87,7 +87,7 @@ hide:
 
 === "zim"
 
-    Додайте `zmodule spaceship-prompt/spaceship-prompt --name spaceship` у `.zimrc` та запустіть `zimfw install`.
+    Додайте `zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules` у `.zimrc` та запустіть `zimfw install`.
 
 === "antigen"
 

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -92,7 +92,7 @@ hide:
 
 === "zim"
 
-    将 `zmodule spaceship-prompt/spaceship-prompt --name spaceship` 添加到您的 `.zimrc`中并且运行 `zimfw install`.
+    将 `zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules` 添加到您的 `.zimrc`中并且运行 `zimfw install`.
 
 === "antigen"
 


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

Starting with Zim 1.8.0, there's the option to disable git submodules. Since the git submodule is tests/shunit2, which is only used for development, it can be disabled for end users.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
