### PR TITLE
Change misspelled word: Threat ➜ Treat

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,7 +112,7 @@ In _iTerm_ follow these instructions:
 
 - Go _iTerm → Preferences… (⌘,) → Profiles → Text_
 - Check _Unicode Version 9 Widths_.
-- Check _Threat ambiguous-width characters as double-width_.
+- Check _Treat ambiguous-width characters as double-width_.
 - Reload terminal's tab.
 
 ## Why doesn't my prompt look like the preview?

--- a/docs/troubleshooting.uk.md
+++ b/docs/troubleshooting.uk.md
@@ -109,7 +109,7 @@ In _iTerm_ follow these instructions:
 
 - Go _iTerm → Preferences… (⌘,) → Profiles → Text_
 - Check _Unicode Version 9 Widths_.
-- Check _Threat ambiguous-width characters as double-width_.
+- Check _Treat ambiguous-width characters as double-width_.
 - Reload terminal's tab.
 
 ## Why doesn't my prompt look like the preview?


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

Fixed a typo where it said `Threat`, but the iTerm option actually has `Treat`.

Check third bullet-point in below screenshot.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->

![image](https://user-images.githubusercontent.com/50134239/154654111-426eff93-5026-47c9-a37f-4f4470e2ba4d.png)
