### PR TITLE
WordPress Version Section

### DIFF
--- a/sections/wordpress.zsh
+++ b/sections/wordpress.zsh
@@ -1,0 +1,43 @@
+#
+# WordPress
+#
+# WordPress is open source software you can use to create a beautiful website, blog, or app.
+# Link: https://wordpress.org/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_WORDPRESS_SHOW="${SPACESHIP_WORDPRESS_SHOW=true}"
+SPACESHIP_WORDPRESS_PREFIX="${SPACESHIP_WORDPRESS_PREFIX="on "}"
+SPACESHIP_WORDPRESS_SUFFIX="${SPACESHIP_WORDPRESS_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_WORDPRESS_SYMBOL="${SPACESHIP_WORDPRESS_SYMBOL="🐱 "}"
+SPACESHIP_WORDPRESS_COLOR="${SPACESHIP_WORDPRESS_COLOR="104"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of WordPress
+spaceship_wordpress() {
+  [[ $SPACESHIP_WORDPRESS_SHOW == false ]] && return
+
+  # Show only if a WordPress config file exists in current path
+  setopt extendedglob
+  local wordpress_glob=(../)#wp-config*.php
+  local wordpress_config=$(ls $wordpress_glob)
+  [[ -z $wordpress_config ]] && return
+
+  # Verify that wp-cli exists
+  spaceship::exists wp || return
+
+  local wordpress_version=$(wp core version 2>/dev/null)
+
+  [[ -z $wordpress_version ]] && return
+
+  spaceship::section \
+    "$SPACESHIP_WORDPRESS_COLOR" \
+    "$SPACESHIP_WORDPRESS_PREFIX" \
+    "${SPACESHIP_WORDPRESS_SYMBOL}v${wordpress_version}" \
+    "${SPACESHIP_WORDPRESS_SUFFIX}"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -57,6 +57,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     swift         # Swift section
     golang        # Go section
     php           # PHP section
+    wordpress     # WordPress section
     rust          # Rust section
     haskell       # Haskell Stack section
     julia         # Julia section


### PR DESCRIPTION
#### Description

Adds the [WordPress](https://wordpress.org) version for the current directory. Globs the path to handle WordPress subdirectories. Depends on [wp-cli](https://wp-cli.org). Icon is supposed to resemble WordPress's mascot, Wapuu.

#### Screenshot

<img width="438" alt="image" src="https://user-images.githubusercontent.com/824344/158234898-c3b319d4-11b1-418c-a7b6-f8486e0ed70e.png">
