### PR TITLE
feat: Adds asdf support to Elixir version finder

### DIFF
--- a/sections/elixir.zsh
+++ b/sections/elixir.zsh
@@ -32,6 +32,8 @@ spaceship_elixir() {
     elixir_version="${ELIXIR_VERSION}"
   elif spaceship::exists exenv; then
     elixir_version=$(exenv version-name)
+  elif spaceship::exists asdf; then
+    elixir_version=${$(asdf current elixir)[2]}
   fi
 
   if [[ $elixir_version == "" ]]; then


### PR DESCRIPTION
#### Description

This pull request makes the Elixir version finder use [asdf](https://asdf-vm.com/) when available.

It gives a great performance boost, as running `elixir -v` is rather slow:

```bash
$ time elixir -v | grep "Elixir" --color=never | cut -d ' ' -f 2
0.86 real
$ time asdf current elixir
0.10 real
```
