### PR TITLE
better way of acquiring jobs amount (fixes #1147)

### DIFF
--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -23,7 +23,7 @@ SPACESHIP_JOBS_AMOUNT_THRESHOLD="${SPACESHIP_JOBS_AMOUNT_THRESHOLD=1}"
 spaceship_jobs() {
   [[ $SPACESHIP_JOBS_SHOW == false ]] && return
 
-  local jobs_amount=$( jobs -d | awk '!/pwd/' | wc -l | tr -d " ")
+  local jobs_amount=${#jobstates}
 
   [[ $jobs_amount -gt 0 ]] || return
 


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

Due to changes to `jobs` in zsh v5.9 the jobs indicator no longer works properly and is always missing one job, see #1147 for more details.

Althouhg I'm leaning more towards a bug in zsh using `${#jobstates}` to count the jobs amount is IMHO a better approach: it doesn't require running a command (arguably better performance) and also removes the dependency of `awk`, `wc` and `tr`.
