### PR TITLE
docs: Update Zim installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This command will download Spaceship. It will also ask you to source Spaceship i
 Add Spaceship to your `.zimrc`:
 
 ```zsh
-zmodule spaceship-prompt/spaceship-prompt --name spaceship
+zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules
 ```
 
 Then install Spaceship:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,7 +101,7 @@ Now that the requirements are satisfied, you can install Spaceship via any of th
     Add Spaceship to your `.zimrc`:
 
     ```zsh title=".zimrc"
-    zmodule spaceship-prompt/spaceship-prompt --name spaceship
+    zmodule spaceship-prompt/spaceship-prompt --name spaceship --no-submodules
     ```
 
     Then install Spaceship:


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->
Starting with Zim 1.8.0, there's the option to disable git submodules.  Since there's a git submodule tests/shunit2, which is only used for development, it can be disabled for end users.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
