### PR TITLE
fix: exec_time doc regarding time threshold trigger

### DIFF
--- a/docs/sections/exec_time.md
+++ b/docs/sections/exec_time.md
@@ -4,11 +4,11 @@ The `exec_time` section displays the execution time of the last command. Will be
 
 ## Defining the threshold
 
-If you are not satisfied with the default threshold of 2 seconds, you can define it using the `SPACESHIP_EXEC_TIME_THRESHOLD` option.
+If you are not satisfied with the default threshold of 2 seconds, you can define it using the `SPACESHIP_EXEC_TIME_ELAPSED` option.
 
 ```zsh title=".zshrc"
 # This sets threshold to 5 seconds
-SPACESHIP_EXEC_TIME_THRESHOLD=5
+SPACESHIP_EXEC_TIME_ELAPSED=5
 ```
 
 ## Defining precision


### PR DESCRIPTION
#### Description

Fixing a slight typo in the `exec_time` user documentation. The environment variable that is used to control the threshold before the execution time is displayed is `SPACESHIP_EXEC_TIME_ELAPSED` and not `SPACESHIP_EXEC_TIME_THRESHOLD `. I've discovered this issue while configuring the section myself.

