### PR TITLE
fix(documentation): use home variable instead of tilde

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ git clone --depth=1 https://github.com/spaceship-prompt/spaceship-prompt.git "$H
 For initializing prompt system add this to your `.zshrc`:
 
 ```zsh title=".zshrc"
-source "${HOME}/.zsh/spaceship/spaceship.zsh"
+source "$HOME/.zsh/spaceship/spaceship.zsh"
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ git clone --depth=1 https://github.com/spaceship-prompt/spaceship-prompt.git "$H
 For initializing prompt system add this to your `.zshrc`:
 
 ```zsh title=".zshrc"
-source "~/.zsh/spaceship/spaceship.zsh"
+source "${HOME}/.zsh/spaceship/spaceship.zsh"
 ```
 </details>
 

--- a/docs/api/environment.md
+++ b/docs/api/environment.md
@@ -53,7 +53,7 @@ A variable storing the path to the configuration file. Usually, this variable st
 You can specify custom path to the configuration file by setting the `SPACESHIP_CONFIG_FILE` environment variable, for example:
 
 ```zsh title="$HOME/.zshrc"
-export SPACESHIP_CONFIG_FILE="${HOME}/.dotfiles/path/to/spaceship.zsh"
+export SPACESHIP_CONFIG_FILE="$HOME/.dotfiles/path/to/spaceship.zsh"
 ```
 
 The variable is empty when no configuration file is found.

--- a/docs/api/environment.md
+++ b/docs/api/environment.md
@@ -53,7 +53,7 @@ A variable storing the path to the configuration file. Usually, this variable st
 You can specify custom path to the configuration file by setting the `SPACESHIP_CONFIG_FILE` environment variable, for example:
 
 ```zsh title="$HOME/.zshrc"
-export SPACESHIP_CONFIG_FILE="~/.dotfiles/path/to/spaceship.zsh"
+export SPACESHIP_CONFIG_FILE="${HOME}/.dotfiles/path/to/spaceship.zsh"
 ```
 
 The variable is empty when no configuration file is found.

--- a/docs/config/intro.md
+++ b/docs/config/intro.md
@@ -52,5 +52,5 @@ You can learn more about available options by reading further documentation.
 Optionally, you can change the location of the configuration file by setting the `SPACESHIP_CONFIG_FILE` environment variable.
 
 ```zsh
-export SPACESHIP_CONFIG_FILE="~/.dotfiles/path/to/spaceship.zsh"
+export SPACESHIP_CONFIG_FILE="${HOME}/.dotfiles/path/to/spaceship.zsh"
 ```

--- a/docs/config/intro.md
+++ b/docs/config/intro.md
@@ -52,5 +52,5 @@ You can learn more about available options by reading further documentation.
 Optionally, you can change the location of the configuration file by setting the `SPACESHIP_CONFIG_FILE` environment variable.
 
 ```zsh
-export SPACESHIP_CONFIG_FILE="${HOME}/.dotfiles/path/to/spaceship.zsh"
+export SPACESHIP_CONFIG_FILE="$HOME/.dotfiles/path/to/spaceship.zsh"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ Now that the requirements are satisfied, you can install Spaceship via any of th
     For initializing prompt system add this to your `.zshrc`:
 
     ```zsh title=".zshrc"
-    source "${HOME}/.zsh/spaceship/spaceship.zsh"
+    source "$HOME/.zsh/spaceship/spaceship.zsh"
     ```
 
 === "Homebrew"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ Now that the requirements are satisfied, you can install Spaceship via any of th
     For initializing prompt system add this to your `.zshrc`:
 
     ```zsh title=".zshrc"
-    source "~/.zsh/spaceship/spaceship.zsh"
+    source "${HOME}/.zsh/spaceship/spaceship.zsh"
     ```
 
 === "Homebrew"


### PR DESCRIPTION
#### Description

I have replaced the tilde with the home variable in a few places, otherwise I got errors in the Windows Subsystem for Linux