### PR TITLE
fix(java): fix version retrieval when JAVA_TOOL_OPTIONS exist in environment

### DIFF
--- a/sections/java.zsh
+++ b/sections/java.zsh
@@ -24,7 +24,7 @@ spaceship_java() {
 
   spaceship::exists java || return
 
-  local java_version=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')
+  local java_version=$(java -version 2>&1 | spaceship::grep version | awk -F '"' '{print $2}')
 
   spaceship::section \
     --color "$SPACESHIP_JAVA_COLOR" \


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

The Java version is not retrieved correctly in at least v4.2.x when the environment variable `JAVA_TOOL_OPTIONS` is defined.

```bash
~/workspace_perso/java-version via ☕ v
➜ java -version
Picked up JAVA_TOOL_OPTIONS: -XX:-MaxFDLimit
openjdk version "11.0.16.1" 2022-07-19 LTS
OpenJDK Runtime Environment Zulu11.58+23-CA (build 11.0.16.1+1-LTS)
OpenJDK 64-Bit Server VM Zulu11.58+23-CA (build 11.0.16.1+1-LTS, mixed mode)
```

#### Screenshot

<img width="314" alt="image" src="https://user-images.githubusercontent.com/3491744/188854534-fca24f6c-e2a9-48ba-b4af-a8038d42cdd2.png">
