### PR TITLE
docs: Fix typo in config prompt

### DIFF
--- a/docs/config/prompt.md
+++ b/docs/config/prompt.md
@@ -38,7 +38,7 @@ The default prompt order is:
 
 ```zsh
 SPACESHIP_PROMPT_ORDER=(
-  time          # Time stampts section
+  time          # Time stamps section
   user          # Username section
   dir           # Current directory section
   host          # Hostname section


### PR DESCRIPTION
Fixed typo of `Time stampts` to `Time stamps`.