### PR TITLE
Delete the redundant space for kubectl symbol (iTerm2)

### DIFF
--- a/docs/sections/kubectl.md
+++ b/docs/sections/kubectl.md
@@ -16,7 +16,7 @@ The `kubectl` section consists of [`kubectl_version`](#kubernetes-version-kubect
 | `SPACESHIP_KUBECTL_PREFIX` |               `at·`                | Section's prefix                      |
 | `SPACESHIP_KUBECTL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                      |
 | `SPACESHIP_KUBECTL_COLOR`  |              `white`               | Section's color of Kubernetes section |
-| `SPACESHIP_KUBECTL_SYMBOL` |               `☸️··`               | Symbol displayed before the section   |
+| `SPACESHIP_KUBECTL_SYMBOL` |               `☸️·`               | Symbol displayed before the section   |
 
 ## Kubernetes version `kubectl_version`
 

--- a/docs/sections/kubectl.md
+++ b/docs/sections/kubectl.md
@@ -16,7 +16,7 @@ The `kubectl` section consists of [`kubectl_version`](#kubernetes-version-kubect
 | `SPACESHIP_KUBECTL_PREFIX` |               `at·`                | Section's prefix                      |
 | `SPACESHIP_KUBECTL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                      |
 | `SPACESHIP_KUBECTL_COLOR`  |              `white`               | Section's color of Kubernetes section |
-| `SPACESHIP_KUBECTL_SYMBOL` |               `☸️·`               | Symbol displayed before the section   |
+| `SPACESHIP_KUBECTL_SYMBOL` |               `☸️·`                 | Symbol displayed before the section   |
 
 ## Kubernetes version `kubectl_version`
 

--- a/sections/kubectl.zsh
+++ b/sections/kubectl.zsh
@@ -11,9 +11,7 @@ SPACESHIP_KUBECTL_ASYNC="${SPACESHIP_KUBECTL_ASYNC=true}"
 SPACESHIP_KUBECTL_PREFIX="${SPACESHIP_KUBECTL_PREFIX="at "}"
 SPACESHIP_KUBECTL_SUFFIX="${SPACESHIP_KUBECTL_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_KUBECTL_COLOR="${SPACESHIP_KUBECTL_COLOR="white"}"
-# Additional space is added because ☸️ is much bigger than the other symbols
-# See: https://github.com/spaceship-prompt/spaceship-prompt/pull/432
-SPACESHIP_KUBECTL_SYMBOL="${SPACESHIP_KUBECTL_SYMBOL="☸️  "}"
+SPACESHIP_KUBECTL_SYMBOL="${SPACESHIP_KUBECTL_SYMBOL="☸️ "}"
 
 # ------------------------------------------------------------------------------
 # Dependencies


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

It is a bug from iTerm2 (and iOS terminal app)

iTerm2 fix this bug.(Since iTerm2 3.5.0beta7). Refer to 

* https://gitlab.com/gnachman/iterm2/-/commit/b316516ee9ba915176bfe883dfae718d05382d90
* https://gitlab.com/gnachman/iterm2/-/issues/10480

<!-- Describe your pull-request, what was changed and why… -->

Also see #432 

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
