### PR TITLE
fix: prepend spaceship root folder to spaceship precompile path

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -119,7 +119,7 @@ for lib in "${SPACESHIP_LIBS[@]}"; do
 done
 
 # Load and precompile this file
-spaceship::precompile "$0"
+spaceship::precompile "$SPACESHIP_ROOT/$0"
 
 # ------------------------------------------------------------------------------
 # BACKWARD COMPATIBILITY WARNINGS


### PR DESCRIPTION

#### Description
When spaceship-prompt precompile libs, it's done by providing the full path to `spaceship::precompile,` but in the case of `prompt_spaceship_setup`/`spaceship.zsh`, that doesn't happen, which leads to issue #1188 

This PR prepends the `$SPACESHIP_ROOT` var to the arguments of that line to provide the full path of the file.

