### PR TITLE
fix(kubectl): Avoid checking kubectl server version if no context is loaded

### DIFF
--- a/sections/kubectl_version.zsh
+++ b/sections/kubectl_version.zsh
@@ -25,6 +25,11 @@ spaceship_kubectl_version() {
 
   spaceship::exists kubectl || return
 
+  # kubectl can hang for upwards of 10 seconds if a context isn't loaded, this avoids the unnecessary server version
+  #  check if a context isn't loaded, avoiding the issue entirely.
+  local kube_context=$(kubectl config current-context 2>/dev/null)
+  [[ -z $kube_context ]] && return
+
   # if kubectl can't connect kubernetes cluster, kubernetes version section will be not shown
   local kubectl_version=$(kubectl version --short 2>/dev/null | grep "Server Version" | sed 's/Server Version: \(.*\)/\1/')
   [[ -z $kubectl_version ]] && return


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

This mirrors the context check code block present within `sections/kubectl_context.zsh` on line 29-30 into `sections/kubectl_version.zsh` at line 27-28, prior to the version check, to ensure that `kubectl` isn't performing a version check if no context is loaded, solving the issue present in issue #1245.

Tested as working with both no context and a context, all works as normal once the fix is applied.

Closes #1245.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

N/A - background script change, no UI/UX change or change to functionality is present.