### PR TITLE
docs(utils): typo in `displaytime` doc

### DIFF
--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -96,7 +96,7 @@ spaceship::deprecated() {
   print -P "%B$deprecated%b is deprecated. $message"
 }
 
-# Display seconds in human readable fromat
+# Display seconds in human readable format
 # For that use `strftime` and convert the duration (float) to seconds (integer).
 # USAGE:
 #   spaceship::displaytime <seconds> [precision]


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

just a simple typo fix