### PR TITLE
feat: add Dart section

### DIFF
--- a/docs/config/prompt.md
+++ b/docs/config/prompt.md
@@ -59,6 +59,7 @@ SPACESHIP_PROMPT_ORDER=(
   rust          # Rust section
   haskell       # Haskell Stack section
   java          # Java section
+  dart          # Dart section
   julia         # Julia section
   crystal       # Crystal section
   docker        # Docker section

--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -164,6 +164,12 @@
       "internal": true
     },
     {
+      "name": "dart",
+      "url": "https://spaceship-prompt.sh/sections/dart",
+      "description": "The current version of Dart.",
+      "internal": true
+    },
+    {
       "name": "jobs",
       "url": "https://spaceship-prompt.sh/sections/jobs",
       "description": "An indicator for jobs running in the background.",

--- a/docs/sections/dart.md
+++ b/docs/sections/dart.md
@@ -1,0 +1,24 @@
+# Dart `dart`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Dart**](https://dart.dev/) is a client-optimized language for fast apps on any platform
+
+The `dart` section displays the current version of Dart.
+
+This section is displayed only when the current directory is within a Dart project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml`, `pubspec.lock` file or `dart_tool` folder
+* Contains any other file with `.dart` extension
+
+## Options
+
+| Variable                           | Default                            | Meaning                             |
+| :--------------------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_DART_SHOW`              | `true`                             | Show section                        |
+| `SPACESHIP_DART_ASYNC`             | `true`                             | Render section asynchronously       |
+| `SPACESHIP_DART_PREFIX`            | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
+| `SPACESHIP_DART_SUFFIX`            | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_DART_SYMBOL`            | `🎯·`                              | Symbol displayed before the section |
+| `SPACESHIP_DART_COLOR`             | `blue`                             | Section's color                     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - Rust (rust): sections/rust.md
         - Haskell (haskell): sections/haskell.md
         - Java (java): sections/java.md
+        - Dart (dart): sections/dart.md
         - Julia (julia): sections/julia.md
         - Crystal (crystal): sections/crystal.md
         - Docker (docker): sections/docker.md

--- a/sections/dart.zsh
+++ b/sections/dart.zsh
@@ -1,0 +1,40 @@
+
+# Dart
+
+# Dart is a client-optimized language for fast apps on any platform
+# Link: https://dart.dev/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+SPACESHIP_DART_SHOW="${SPACESHIP_DART_SHOW=true}"
+SPACESHIP_DART_ASYNC="${SPACESHIP_DART_ASYNC=true}"
+SPACESHIP_DART_PREFIX="${SPACESHIP_DART_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_DART_SUFFIX="${SPACESHIP_DART_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_DART_SYMBOL="${SPACESHIP_DART_SYMBOL="🎯 "}"
+SPACESHIP_DART_COLOR="${SPACESHIP_DART_COLOR="blue"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_dart() {
+  [[ $SPACESHIP_DART_SHOW == false ]] && return
+  spaceship::exists dart || return
+
+  local is_dart_project="$(spaceship::upsearch pubspec.yaml pubspec.yml pubspec.lock dart_tool)"
+  [[ -n "$is_dart_project" || -n *.dart(#qN^/) ]] || return
+
+  # The Dart binary can be installed directly as 'dart-sdk' or as bundle via Flutter
+  # The version can have the following patterns:
+  # dart-sdk >       Dart SDK version: 2.19.0-edge.efb509c114dcaf54d0a011f717b48893d71ec9c3 (be) (Thu Sep 29 01:58:56 2022 +0000) on "macos_x64"
+  # flutter bundle > Dart SDK version: 2.18.1 (stable) (Tue Sep 13 11:42:55 2022 +0200) on "macos_x64"
+  local dart_version=$(dart --version | awk '{sub(/-.*/, "", $4); print $4}')
+
+  spaceship::section \
+    --color "$SPACESHIP_DART_COLOR" \
+    --prefix "$SPACESHIP_DART_PREFIX" \
+    --suffix "$SPACESHIP_DART_SUFFIX" \
+    --symbol "${SPACESHIP_DART_SYMBOL}" \
+    "v${dart_version}"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -57,6 +57,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     rust          # Rust section
     haskell       # Haskell Stack section
     java          # Java section
+    dart          # Dart section
     julia         # Julia section
     crystal       # Crystal section
     docker        # Docker section

--- a/tests/dart.test.zsh
+++ b/tests/dart.test.zsh
@@ -1,0 +1,121 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  DART_VERSION="2.19.0"
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(dart)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_DART_SHOW="true"
+  SPACESHIP_DART_PREFIX="via "
+  SPACESHIP_DART_SUFFIX=""
+  SPACESHIP_DART_SYMBOL="🎯 "
+  SPACESHIP_DART_COLOR="blue"
+
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_DART_SHOW
+  unset SPACESHIP_DART_PREFIX
+  unset SPACESHIP_DART_SUFFIX
+  unset SPACESHIP_DART_SYMBOL
+  unset SPACESHIP_DART_COLOR
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_no_files() {
+  local expected=""
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without files" "$expected" "$actual"
+}
+
+test_dart_upsearch_file() {
+  FILES=( pubspec.yaml pubspec.yml pubspec.lock )
+  for file in $FILES; do
+    touch $file
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+test_dart_upsearch_dir() {
+  DIRS=( dart_tool )
+  for dir in $DIRS; do
+    mkdir $dir
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with $dir" "$expected" "$actual"
+    rm -rf $dir
+  done
+}
+
+test_dart_file_extension() {
+  FILES=(first.dart second.dart)
+  for file in $FILES; do
+    touch $file
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+test_dart_flutter() {
+  # alias to mock dart command bundled with flutter
+  alias "dart"="printf 'Dart SDK version: 2.18.1 (stable) (Tue Sep 13 11:42:55 2022 +0200) on \"macos_x64\"'\n"
+  local DART_VERSION="2.18.1"
+  file="main.dart" 
+  touch $file
+  local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with $file" "$expected" "$actual"
+  rm $file
+}
+
+test_dart_sdk() {
+  # alias to mock dart command installed as dart-sdk
+  alias "dart"="printf 'Dart SDK version: 2.19.0-edge.efb509c114dcaf54d0a011f717b48893d71ec9c3 (be) (Thu Sep 29 01:58:56 2022 +0000) on \"macos_x64\"'\n"
+  local DART_VERSION="2.19.0"
+  file="main.dart" 
+  touch $file
+  local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with $file" "$expected" "$actual"
+  rm $file
+}
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source tests/shunit2/shunit2

--- a/tests/stubs/dart
+++ b/tests/stubs/dart
@@ -1,0 +1,1 @@
+printf 'Dart SDK version: 2.19.0-edge.efb509c114dcaf54d0a011f717b48893d71ec9c3 (be) (Thu Sep 29 01:58:56 2022 +0000) on "macos_x64"\n'


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

Added Dart section #1213

* Upsearch finds a `pubspec.yaml`, `pubspec.yml`, `pubspec.lock` file or `dart_tool` folder
* Contains any other file with `.dart` extension

| Variable                           | Default                            | Meaning                             |
| :--------------------------------- | :--------------------------------: | ----------------------------------- |
| `SPACESHIP_DART_SHOW`              | `true`                             | Show section                        |
| `SPACESHIP_DART_ASYNC`             | `true`                             | Render section asynchronously       |
| `SPACESHIP_DART_PREFIX`            | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
| `SPACESHIP_DART_SUFFIX`            | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
| `SPACESHIP_DART_SYMBOL`            | `🎯·`                              | Symbol displayed before the section |
| `SPACESHIP_DART_COLOR`             | `blue`                             | Section's color                     |

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
![image](https://user-images.githubusercontent.com/60756/193801039-18abe242-2ea9-4031-bdae-7be7be3bc21c.png)
