### PR TITLE
add flutter section

### DIFF
--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -164,6 +164,12 @@
       "internal": true
     },
     {
+      "name": "flutter",
+      "url": "https://spaceship-prompt.sh/sections/flutter",
+      "description": "The current version and channel of the Flutter framework.",
+      "internal": true
+    },
+    {
       "name": "jobs",
       "url": "https://spaceship-prompt.sh/sections/jobs",
       "description": "An indicator for jobs running in the background.",

--- a/docs/sections/flutter.de.md
+++ b/docs/sections/flutter.de.md
@@ -1,0 +1,27 @@
+# Flutter `flutter`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Flutter**](https://flutter.dev/) is an open source framework for building multi-platform applications
+
+The `flutter` section displays the current version and channel of Flutter.
+
+This section is displayed only when the current directory is within a Flutter project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml` file and it contains `flutter` dependency.
+
+## Options
+
+| Variable                           | Default                             | Meaning                             |
+| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
+| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
+| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
+| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
+| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
+| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
+| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
+| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
+| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel |

--- a/docs/sections/flutter.md
+++ b/docs/sections/flutter.md
@@ -1,0 +1,27 @@
+# Flutter `flutter`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Flutter**](https://flutter.dev/) is an open source framework for building multi-platform applications
+
+The `flutter` section displays the current version and channel of Flutter.
+
+This section is displayed only when the current directory is within a Flutter project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml` file and it contains `flutter` dependency.
+
+## Options
+
+| Variable                           | Default                             | Meaning                             |
+| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
+| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
+| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
+| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
+| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
+| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
+| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
+| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
+| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel |

--- a/docs/sections/flutter.pl.md
+++ b/docs/sections/flutter.pl.md
@@ -1,0 +1,27 @@
+# Flutter `flutter`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Flutter**](https://flutter.dev/) is an open source framework for building multi-platform applications
+
+The `flutter` section displays the current version and channel of Flutter.
+
+This section is displayed only when the current directory is within a Flutter project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml` file and it contains `flutter` dependency.
+
+## Options
+
+| Variable                           | Default                             | Meaning                             |
+| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
+| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
+| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
+| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
+| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
+| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
+| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
+| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
+| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel |

--- a/docs/sections/flutter.uk.md
+++ b/docs/sections/flutter.uk.md
@@ -1,0 +1,27 @@
+# Flutter `flutter`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Flutter**](https://flutter.dev/) is an open source framework for building multi-platform applications
+
+The `flutter` section displays the current version and channel of Flutter.
+
+This section is displayed only when the current directory is within a Flutter project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml` file and it contains `flutter` dependency.
+
+## Options
+
+| Variable                           | Default                             | Meaning                             |
+| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
+| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
+| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
+| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
+| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
+| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
+| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
+| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
+| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel |

--- a/docs/sections/flutter.zh.md
+++ b/docs/sections/flutter.zh.md
@@ -1,0 +1,27 @@
+# Flutter `flutter`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Flutter**](https://flutter.dev/) is an open source framework for building multi-platform applications
+
+The `flutter` section displays the current version and channel of Flutter.
+
+This section is displayed only when the current directory is within a Flutter project, meaning:
+
+* Upsearch finds a `pubspec.yaml`, `pubspec.yml` file and it contains `flutter` dependency.
+
+## Options
+
+| Variable                           | Default                             | Meaning                             |
+| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
+| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
+| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
+| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
+| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
+| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
+| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
+| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
+| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
+| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - Rust (rust): sections/rust.md
         - Haskell (haskell): sections/haskell.md
         - Java (java): sections/java.md
+        - Flutter (flutter): sections/flutter.md
         - Julia (julia): sections/julia.md
         - Crystal (crystal): sections/crystal.md
         - Docker (docker): sections/docker.md

--- a/sections/flutter.zsh
+++ b/sections/flutter.zsh
@@ -1,0 +1,55 @@
+
+# Flutter
+
+# Flutter is an open source framework for building multi-platform applications
+# Link: https://flutter.dev/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+SPACESHIP_FLUTTER_SHOW="${SPACESHIP_FLUTTER_SHOW=true}"
+SPACESHIP_FLUTTER_ASYNC="${SPACESHIP_FLUTTER_ASYNC=true}"
+SPACESHIP_FLUTTER_PREFIX="${SPACESHIP_FLUTTER_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_FLUTTER_SUFFIX="${SPACESHIP_FLUTTER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_FLUTTER_SYMBOL="${SPACESHIP_FLUTTER_SYMBOL="💙 "}"
+SPACESHIP_FLUTTER_COLOR="${SPACESHIP_FLUTTER_COLOR="blue"}"
+SPACESHIP_FLUTTER_CHANNEL_SHOW="${SPACESHIP_FLUTTER_CHANNEL_SHOW=true}"
+SPACESHIP_FLUTTER_CHANNEL_PREFIX="${SPACESHIP_FLUTTER_CHANNEL_PREFIX=""}"
+SPACESHIP_FLUTTER_CHANNEL_SUFFIX="${SPACESHIP_FLUTTER_CHANNEL_SUFFIX=""}"
+SPACESHIP_FLUTTER_CHANNEL_SYMBOL="${SPACESHIP_FLUTTER_CHANNEL_SYMBOL=" #"}"
+
+# ------------------------------------------------------------------------------
+# Section(s)
+# ------------------------------------------------------------------------------
+spaceship_flutter() {
+  [[ $SPACESHIP_FLUTTER_SHOW == false ]] && return
+  spaceship::exists flutter || return
+
+  local pubspec_file=$(spaceship::upsearch pubspec.yaml pubspec.yml) || return
+  local is_flutter_project="$(spaceship::datafile --yaml $pubspec_file "dependencies.flutter")"
+
+  [[ -n "$is_flutter_project" &&  "$is_flutter_project" != "null" ]] || return
+
+  local flutter_version_output=$(flutter --version | head -n 1)
+  local flutter_version=$(echo "$flutter_version_output" | awk '{print $2}')
+  local flutter_channel=$(echo "$flutter_version_output" | awk '{print $5}')
+  local flutter_channel_section="$(__spaceship_flutter_channel $flutter_channel)"
+
+
+  spaceship::section \
+    --color "$SPACESHIP_FLUTTER_COLOR" \
+    --prefix "$SPACESHIP_FLUTTER_PREFIX" \
+    --suffix "$SPACESHIP_FLUTTER_SUFFIX" \
+    --symbol "${SPACESHIP_FLUTTER_SYMBOL}" \
+    "v${flutter_version}${flutter_channel_section}"
+
+}
+
+# internal section for channel
+#   param: channel
+__spaceship_flutter_channel() {
+  [[ $SPACESHIP_FLUTTER_CHANNEL_SHOW == false ]] && return
+
+  local flutter_channel=${1:?"unknown"}
+  echo -n "$SPACESHIP_FLUTTER_CHANNEL_SYMBOL$SPACESHIP_FLUTTER_CHANNEL_PREFIX${flutter_channel}$SPACESHIP_FLUTTER_CHANNEL_SUFFIX"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -57,6 +57,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     rust          # Rust section
     haskell       # Haskell Stack section
     java          # Java section
+    flutter       # Flutter section
     julia         # Julia section
     crystal       # Crystal section
     docker        # Docker section


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

add Flutter section

Upsearch for file `pubspec.yaml` or `pubspec.yml` and ensure it contains a `flutter` dependency.
It will also show the current channel by default.
Flutter uses the Dart language but it is a separate section

| Variable                           | Default                             | Meaning                             |
| :--------------------------------- | :--------------------------------:  | ----------------------------------- |
| `SPACESHIP_FLUTTER_SHOW`           | `true`                              | Show section                        |
| `SPACESHIP_FLUTTER_ASYNC`          | `true`                              | Render section asynchronously       |
| `SPACESHIP_FLUTTER_PREFIX`         | `$SPACESHIP_PROMPT_DEFAULT_PREFIX`  | Section's prefix                    |
| `SPACESHIP_FLUTTER_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX`  | Section's suffix                    |
| `SPACESHIP_FLUTTER_SYMBOL`         | `💙·`                               | Symbol displayed before the section |
| `SPACESHIP_FLUTTER_COLOR`          | `blue`                              | Section's color                     |
| `SPACESHIP_FLUTTER_CHANNEL_SHOW`   | `true`                              | Show channel                        |
| `SPACESHIP_FLUTTER_CHANNEL_PREFIX` | ``                                  | Channel's prefix                    |
| `SPACESHIP_FLUTTER_CHANNEL_SUFFIX` | ``                                  | Channel's suffix                    |
| `SPACESHIP_FLUTTER_CHANNEL_SYMBOL` | `.#`                                | Symbol displayed before the channel | 

#### Screenshot

<!-- Please, attach a screenshot, if possible. -->
**stable channel**
![image](https://user-images.githubusercontent.com/60756/193797940-eed13fe8-c479-4731-9532-c9b7675e19d7.png)
**beta channel**
![image](https://user-images.githubusercontent.com/60756/193800219-06c5b02e-12f8-4983-856a-94dd5551a5d2.png)
