### PR TITLE
fix locale dependent test (test_displaytime)

### DIFF
--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -148,6 +148,7 @@ test_deprecated() {
 }
 
 test_displaytime() {
+  local LC_NUMERIC="en_US.UTF-8"
   local expected='14d 6h 56m 7.0s'
   local actual=$(spaceship::displaytime 1234567)
 


### PR DESCRIPTION
the `test_displaytime` test is locale dependent (LC_NUMERIC) and will fail if numeric locale is set to a country code with comma as decimal separator, e.g. `LC_NUMERIC="sv_SE.UTF-8"`

 
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
