### PR TITLE
add Lua section

### DIFF
--- a/docs/config/prompt.md
+++ b/docs/config/prompt.md
@@ -59,6 +59,7 @@ SPACESHIP_PROMPT_ORDER=(
   rust          # Rust section
   haskell       # Haskell Stack section
   java          # Java section
+  lua           # Lua section
   julia         # Julia section
   crystal       # Crystal section
   docker        # Docker section

--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -164,6 +164,12 @@
       "internal": true
     },
     {
+      "name": "lua",
+      "url": "https://spaceship-prompt.sh/sections/lua",
+      "description": "The current version of the Lua compiler.",
+      "internal": true
+    },
+    {
       "name": "jobs",
       "url": "https://spaceship-prompt.sh/sections/jobs",
       "description": "An indicator for jobs running in the background.",

--- a/docs/sections/lua.md
+++ b/docs/sections/lua.md
@@ -1,0 +1,24 @@
+# Lua `lua`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Lua**](https://lua.org/) is a powerful, efficient, lightweight, embeddable scripting language
+
+The `lua` section displays the Lua version.
+
+This section is displayed only when the current directory:
+
+* Upsearch finds `.lua-version` file or `lua` directory
+* Current directory contains any file with `.lua` extension
+
+## Options
+
+| Variable                   |              Default               | Meaning                             |
+| :------------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_LUA_SHOW`       |               `true`               | Show section                        |
+| `SPACESHIP_LUA_ASYNC`      |               `true`               | Render section asynchronously       |
+| `SPACESHIP_LUA_PREFIX`     | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
+| `SPACESHIP_LUA_SUFFIX`     | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_LUA_SYMBOL`     |               `🌙 `                | Symbol displayed before the section |
+| `SPACESHIP_LUA_COLOR`      |               `cyan`               | Section's color                     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - Rust (rust): sections/rust.md
         - Haskell (haskell): sections/haskell.md
         - Java (java): sections/java.md
+        - Lua (lua): sections/lua.md
         - Julia (julia): sections/julia.md
         - Crystal (crystal): sections/crystal.md
         - Docker (docker): sections/docker.md

--- a/sections/lua.zsh
+++ b/sections/lua.zsh
@@ -1,0 +1,34 @@
+# Lua
+#
+# Lua is a powerful, efficient, lightweight, embeddable scripting language
+# Link: https://lua.org/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+SPACESHIP_LUA_SHOW="${SPACESHIP_LUA_SHOW=true}"
+SPACESHIP_LUA_ASYNC="${SPACESHIP_LUA_ASYNC=true}"
+SPACESHIP_LUA_PREFIX="${SPACESHIP_LUA_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_LUA_SUFFIX="${SPACESHIP_LUA_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_LUA_SYMBOL="${SPACESHIP_LUA_SYMBOL="🌙 "}"
+SPACESHIP_LUA_COLOR="${SPACESHIP_LUA_COLOR="cyan"}"
+
+# ------------------------------------------------------------------------------
+# Section(s)
+# ------------------------------------------------------------------------------
+spaceship_lua() {
+  [[ $SPACESHIP_LUA_SHOW == false ]] && return
+  spaceship::exists lua || return
+
+  local is_lua_project="$(spaceship::upsearch .lua-version lua)"
+  [[ -n "$is_lua_project" || -n *.lua(#qN^/) ]] || return
+
+  local lua_version=$(lua -v | awk '{print $2}')
+
+  spaceship::section \
+    --color "$SPACESHIP_LUA_COLOR" \
+    --prefix "$SPACESHIP_LUA_PREFIX" \
+    --suffix "$SPACESHIP_LUA_SUFFIX" \
+    --symbol "${SPACESHIP_LUA_SYMBOL}" \
+    "v${lua_version}"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -57,6 +57,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     rust          # Rust section
     haskell       # Haskell Stack section
     java          # Java section
+    lua           # Lua section
     julia         # Julia section
     crystal       # Crystal section
     docker        # Docker section

--- a/tests/lua.test.zsh
+++ b/tests/lua.test.zsh
@@ -1,0 +1,97 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  LUA_VERSION="5.4.4"
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(lua)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_LUA_SHOW="true"
+  SPACESHIP_LUA_PREFIX="via "
+  SPACESHIP_LUA_SUFFIX=""
+  SPACESHIP_LUA_SYMBOL="🌙 "
+  SPACESHIP_LUA_COLOR="cyan"
+
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_LUA_SHOW
+  unset SPACESHIP_LUA_PREFIX
+  unset SPACESHIP_LUA_SUFFIX
+  unset SPACESHIP_LUA_SYMBOL
+  unset SPACESHIP_LUA_COLOR
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_lua_no_files() {
+  local expected=""
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without files" "$expected" "$nactual"
+}
+
+test_lua_upsearch_file() {
+  FILES=( .lua-version )
+  for file in $FILES; do
+    touch $file
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_LUA_COLOR}%}${SPACESHIP_LUA_SYMBOL}v${LUA_VERSION}%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with file $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+test_lua_upsearch_dir() {
+  DIRS=( lua )
+  for dir in $DIRS; do
+    mkdir $dir
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_LUA_COLOR}%}${SPACESHIP_LUA_SYMBOL}v${LUA_VERSION}%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with dir $dir" "$expected" "$actual"
+    rm -rf $dir
+  done
+}
+
+test_lua_file_extension() {
+  FILES=( first.lua second.lua )
+  for file in $FILES; do
+    touch $file
+    local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_LUA_COLOR}%}${SPACESHIP_LUA_SYMBOL}v${LUA_VERSION}%{%b%f%}"
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with extension for file $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source tests/shunit2/shunit2

--- a/tests/stubs/lua
+++ b/tests/stubs/lua
@@ -1,0 +1,3 @@
+#!/usr/bin/env zsh
+
+printf 'Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio\n'


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

Add Lua section , see #1218 

- [x] Add a section to `sections` folder.
- [x] Include a section to prompt order options in `spaceship.zsh` file.
- [x] Add tests for section in `tests` folder.
- [x] Add documentation for a section in `docs/sections` folder.
  - [x] Include a reference for section in `mkdocs.yml` file.
  - [x] Include a reference for section in `config/prompt.md` file.
- [x] Add a section to the registry in `docs/registry/internal.json`

## Options

| Variable                   |              Default               | Meaning                             |
| :------------------------- | :--------------------------------: | ----------------------------------- |
| `SPACESHIP_LUA_SHOW`       |               `true`               | Show section                        |
| `SPACESHIP_LUA_ASYNC`      |               `true`               | Render section asynchronously       |
| `SPACESHIP_LUA_PREFIX`     | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
| `SPACESHIP_LUA_SUFFIX`     | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
| `SPACESHIP_LUA_SYMBOL`     |               `🌙 `                | Symbol displayed before the section |
| `SPACESHIP_LUA_COLOR`      |               `cyan`               | Section's color                     |

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
![image](https://user-images.githubusercontent.com/60756/194483990-843a6b3f-3c2c-42dd-b0f8-8d5a9613f63a.png)

