### PR TITLE
Update node.zsh

### DIFF
--- a/docs/sections/node.md
+++ b/docs/sections/node.md
@@ -12,6 +12,7 @@ This section is displayed only when the current directory is within a Node.js pr
 * Upsearch finds a `package.json` file
 * Upsearch finds a `node_modules` folder
 * Upsearch finds a `.nvmrc` file
+* Upsearch finds a `.node-version` file
 * Contains any other file with `.js`, `.cjs` or `.mjs` extension
 
 ## Setting the default Node.js version

--- a/docs/sections/node.md
+++ b/docs/sections/node.md
@@ -5,13 +5,14 @@
 !!! info
     [**Node.js**](https://nodejs.org) is a JavaScript runtime built on Chrome's V8 JavaScript engine.
 
-The `node` section displays the current version of the Node.js binary. This section supports [nvm](https://github.com/nvm-sh/nvm)](https://github.com/nvm-sh/nvm), [nodenv](https://github.com/nodenv/nodenv), [fnm](https://github.com/Schniz/fnm) version managers or uses `node -v` if non of the above is installed.
+The `node` section displays the current version of the Node.js binary. This section supports [nvm](https://github.com/nvm-sh/nvm), [nodenv](https://github.com/nodenv/nodenv), [fnm](https://github.com/Schniz/fnm) version managers or uses `node -v` if non of the above is installed.
 
 This section is displayed only when the current directory is within a Node.js project, meaning:
 
 * Upsearch finds a `package.json` file
 * Upsearch finds a `node_modules` folder
-* Contains any other file with `.js` extension
+* Upsearch finds a `.nvmrc` file
+* Contains any other file with `.js`, `.cjs` or `.mjs` extension
 
 ## Setting the default Node.js version
 

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -25,7 +25,7 @@ spaceship_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
 
   # Show NODE status only for JS-specific folders
-  local is_node_project="$(spaceship::upsearch package.json node_modules .nvmrc)"
+  local is_node_project="$(spaceship::upsearch package.json .nvmrc .node-version node_modules)"
   [[ -n "$is_node_project" || -n *.js(#qN^/) || -n *.cjs(#qN^/) || -n *.mjs(#qN^/) ]] || return
 
   local node_version

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -25,7 +25,7 @@ spaceship_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
 
   # Show NODE status only for JS-specific folders
-  local is_node_project="$(spaceship::upsearch package.json node_modules)"
+  local is_node_project="$(spaceship::upsearch package.json node_modules .nvmrc)"
   [[ -n "$is_node_project" || -n *.js(#qN^/) || -n *.cjs(#qN^/) || -n *.mjs(#qN^/) ]] || return
 
   local node_version

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -26,7 +26,7 @@ spaceship_node() {
 
   # Show NODE status only for JS-specific folders
   local is_node_project="$(spaceship::upsearch package.json node_modules)"
-  [[ -n "$is_node_project" || -n *.js(#qN^/) ]] || return
+  [[ -n "$is_node_project" || -n *.js(#qN^/) || -n *.cjs(#qN^/) || -n *.mjs(#qN^/) ]] || return
 
   local node_version
 


### PR DESCRIPTION
Treat a folder that contains an `.nvmrc` as well as Node project

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

So far only folders with a `package.json` file, a `node_modules` directory or pure `*.js` files in it are treated as Node projects. If tooling is using the extensions `*.cjs` or `*.mjs` the section is not showing up.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
