### PR TITLE
Add short option to dir section like fish shell

### DIFF
--- a/docs/sections/dir.md
+++ b/docs/sections/dir.md
@@ -20,17 +20,18 @@ If the current directory is write-protected or if the current user doesn't have 
 
 ## Options
 
-| Variable                     |              Default               | Meaning                                                                             |
-| :--------------------------- | :--------------------------------: | ----------------------------------------------------------------------------------- |
-| `SPACESHIP_DIR_SHOW`         |               `true`               | Show section                                                                        |
-| `SPACESHIP_DIR_PREFIX`       |                `in·`               | Section's prefix                                                                    |
-| `SPACESHIP_DIR_SUFFIX`       | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                                                                    |
-| `SPACESHIP_DIR_TRUNC`        |                 `3`                | Number of folders of cwd to show in prompt, 0 to show all                           |
-| `SPACESHIP_DIR_TRUNC_PREFIX` |                  -                 | Prefix before cwd when it's truncated. For example `…/` or `.../`, empty to disable |
-| `SPACESHIP_DIR_TRUNC_REPO`   |               `true`               | While in `git` repo, show only root directory and folders inside it                 |
-| `SPACESHIP_DIR_COLOR`        |               `cyan`               | Section's color                                                                     |
-| `SPACESHIP_DIR_LOCK_SYMBOL`  | ![·][lock-icon]                   | The symbol displayed if directory is write-protected                                |
-| `SPACESHIP_DIR_LOCK_COLOR`   |               `red`                | Color for the lock symbol                                                           |
+| Variable                     |              Default               | Meaning                                                                                   |
+| :--------------------------- | :--------------------------------: | ----------------------------------------------------------------------------------------- |
+| `SPACESHIP_DIR_SHOW`         |               `true`               | Show section                                                                              |
+| `SPACESHIP_DIR_PREFIX`       |                `in·`               | Section's prefix                                                                          |
+| `SPACESHIP_DIR_SUFFIX`       | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                                                                          |
+| `SPACESHIP_DIR_TRUNC`        |                 `3`                | Number of folders of cwd to show in prompt, 0 to show all                                 |
+| `SPACESHIP_DIR_TRUNC_PREFIX` |                  -                 | Prefix before cwd when it's truncated. For example `…/` or `.../`, empty to disable       |
+| `SPACESHIP_DIR_TRUNC_REPO`   |               `true`               | While in `git` repo, show only root directory and folders inside it                       |
+| `SPACESHIP_DIR_SHORT`        |               `false`              | Show a minimalistic view of the path by only printing the first letter of parent folders. |
+| `SPACESHIP_DIR_COLOR`        |               `cyan`               | Section's color                                                                           |
+| `SPACESHIP_DIR_LOCK_SYMBOL`  | ![·][lock-icon]                   | The symbol displayed if directory is write-protected                                      |
+| `SPACESHIP_DIR_LOCK_COLOR`   |               `red`                | Color for the lock symbol                                                                 |
 
 <!-- References -->
 

--- a/sections/dir.zsh
+++ b/sections/dir.zsh
@@ -16,6 +16,7 @@ SPACESHIP_DIR_TRUNC_REPO="${SPACESHIP_DIR_TRUNC_REPO=true}"
 SPACESHIP_DIR_COLOR="${SPACESHIP_DIR_COLOR="cyan"}"
 SPACESHIP_DIR_LOCK_SYMBOL="${SPACESHIP_DIR_LOCK_SYMBOL=" "}"
 SPACESHIP_DIR_LOCK_COLOR="${SPACESHIP_DIR_LOCK_COLOR="red"}"
+SPACESHIP_DIR_SHORT="${SPACESHIP_DIR_SHORT=false}"
 
 # ------------------------------------------------------------------------------
 # Section
@@ -64,6 +65,21 @@ spaceship_dir() {
 
   if [[ ! -w . ]]; then
     suffix="%F{$SPACESHIP_DIR_LOCK_COLOR}${SPACESHIP_DIR_LOCK_SYMBOL}%f${SPACESHIP_DIR_SUFFIX}"
+  fi
+
+  if [[ $SPACESHIP_DIR_SHORT == true ]]; then
+      local i pwd
+      pwd=("${(s:/:)PWD/#$HOME/~}")
+      if (( $#pwd > 1 )); then
+        for i in {1..$(($#pwd-1))}; do
+          if [[ "$pwd[$i]" = .* ]]; then
+            pwd[$i]="${${pwd[$i]}[1,2]}"
+          else
+            pwd[$i]="${${pwd[$i]}[1]}"
+          fi
+        done
+      fi
+      dir="${(j:/:)pwd}"
   fi
 
   spaceship::section \


### PR DESCRIPTION
#### Description

Fixes #897. 

I dunno if the placement is right because I was confused by the repo truncate code above :-).
The code was copied by fish shell: https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/fishy.zsh-theme

#### Screenshot

* Path: 
  * `/usr/local/opt/spaceship/sections`
* Path with standard `TRUNC` setting: 
  * `…/opt/spaceship/sections`
* Path with this pull request:
![Short path](https://user-images.githubusercontent.com/72547405/196268690-45be3b26-30ed-4fb3-a5ef-48e9d9274adb.png)

