### PR TITLE
Bugfix detect root via version variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,12 @@ When adding a new section to Spaceship, here's a checklist you should follow:
 
 1. **Fork** this repo (click the _fork_ button)
 1. **Clone** your fork to your working machine (via `git clone`)
-1. **Switch to `next` branch** by running `git checkout next`.
 1. **Update submodules** in your fork (via `git submodule update --init --recursive`)
 1. **Make your changes**. Check our [API](https://spaceship-prompt.sh/api) for more information (we suggest you to check out a new branch for changes).
 1. **Test** your code (via `make tests`)
 1. **Add and commit** your contributions
 1. **Push** your changes to your remote fork
-1. **Open a pull-request** to our primary repo and target `next` branch.
+1. **Open a pull-request** to our primary repo and target `master` branch.
 1. **Wait for review**, get your PR reviewed and merged.
 
 ## Testing

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -12,12 +12,16 @@ export SPACESHIP_VERSION='4.7.0'
 
 # Determination of Spaceship working directory
 # https://git.io/vdBH7
-spaceship::root() {
+#
+# Set SPACESHIP_ROOT if it isn't defined yet or if the directory does
+# not exist anymore (e.g. after an update to a newer version)
+# See https://github.com/spaceship-prompt/spaceship-prompt/pull/1280
+if [[ -z "$SPACESHIP_ROOT" || ! -d "$SPACESHIP_ROOT" ]]; then
   if [[ "${(%):-%N}" == '(eval)' ]]; then
     if [[ "$0" == '-antigen-load' ]] && [[ -r "${PWD}/spaceship.zsh" ]]; then
       # Antigen uses eval to load things so it can change the plugin (!!)
       # https://github.com/zsh-users/antigen/issues/581
-      echo $PWD
+      export -r SPACESHIP_ROOT="$PWD"
     else
       print -P "%F{red}You must set SPACESHIP_ROOT to work from within an (eval).%f"
       return 1
@@ -26,14 +30,8 @@ spaceship::root() {
     # Get the path to file this code is executing in; then
     # get the absolute path and strip the filename.
     # See https://stackoverflow.com/a/28336473/108857
-    echo ${${(%):-%x}:A:h}
+    export -r SPACESHIP_ROOT="${${(%):-%x}:A:h}"
   fi
-}
-if [[ -z "$SPACESHIP_ROOT" || ! -d "$SPACESHIP_ROOT" ]]; then
-  # Set SPACESHIP_ROOT if it isn't defined yet or if the directory does
-  # not exist anymore (e.g. after an update to a newer version)
-  # See https://github.com/spaceship-prompt/spaceship-prompt/pull/1280
-  export -r SPACESHIP_ROOT="$(spaceship::root)"
 fi
 
 # ------------------------------------------------------------------------------

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -12,12 +12,12 @@ export SPACESHIP_VERSION='4.7.0'
 
 # Determination of Spaceship working directory
 # https://git.io/vdBH7
-if [[ -z "$SPACESHIP_ROOT" ]]; then
+spaceship::root() {
   if [[ "${(%):-%N}" == '(eval)' ]]; then
     if [[ "$0" == '-antigen-load' ]] && [[ -r "${PWD}/spaceship.zsh" ]]; then
       # Antigen uses eval to load things so it can change the plugin (!!)
       # https://github.com/zsh-users/antigen/issues/581
-      export -r SPACESHIP_ROOT=$PWD
+      echo $PWD
     else
       print -P "%F{red}You must set SPACESHIP_ROOT to work from within an (eval).%f"
       return 1
@@ -26,8 +26,14 @@ if [[ -z "$SPACESHIP_ROOT" ]]; then
     # Get the path to file this code is executing in; then
     # get the absolute path and strip the filename.
     # See https://stackoverflow.com/a/28336473/108857
-    export -r SPACESHIP_ROOT=${${(%):-%x}:A:h}
+    echo ${${(%):-%x}:A:h}
   fi
+}
+if [[ -z "$SPACESHIP_ROOT" || ! -d "$SPACESHIP_ROOT" ]]; then
+  # Set SPACESHIP_ROOT if it isn't defined yet or if the directory does
+  # not exist anymore (e.g. after an update to a newer version)
+  # See https://github.com/spaceship-prompt/spaceship-prompt/pull/1280
+  export -r SPACESHIP_ROOT="$(spaceship::root)"
 fi
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### Description

This fixes #1140 in my case. It basically checks if the given directory exists and if not tries to replace the version in the path with the current version. Here's a small script that probably helps to understand what's going on:

```zsh
SPACESHIP_VERSION="4.7.0"
SPACESHIP_ROOT="/opt/homebrew/Cellar/spaceship/4.6.1"

echo "before:\t$SPACESHIP_ROOT"
TRY_SPACESHIP_ROOT="${SPACESHIP_ROOT%/*}/$SPACESHIP_VERSION"
echo "after:\t$TRY_SPACESHIP_ROOT"
print -P "%F{red}Not able to detect SPACESHIP_ROOT, tried $SPACESHIP_ROOT and $TRY_SPACESHIP_ROOT.%f"
```

![image](https://user-images.githubusercontent.com/1001186/199693129-71b19e67-b003-4471-91d7-b20008b46479.png)


#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
