### PR TITLE
Fixed showing java version in maven projects

### DIFF
--- a/sections/java.zsh
+++ b/sections/java.zsh
@@ -23,7 +23,7 @@ spaceship_java() {
   spaceship::exists java || return
 
   # Detect java project
-  local is_java_project="$(spaceship::upsearch pom.xml build.gradle* settings.gradle* build.xml)"
+  local is_java_project="$(spaceship::upsearch pom.xml 'build.gradle*' 'settings.gradle*' build.xml)"
   [[ -n "$is_java_project" || -n *.(java|class|jar|war)(#qN^/) ]] || return
 
   # Extract java version


### PR DESCRIPTION
#### Description

After this [PR](https://github.com/spaceship-prompt/spaceship-prompt/pull/1289) the java version in maven projects is no longer displayed

#### Screenshot

<!-- Please, attach a screenshot, if possible.

after changes:
<img width="857" alt="image" src="https://user-images.githubusercontent.com/31127283/201060937-9382df38-9bd3-4be1-a768-1d35164636a0.png">

