### PR TITLE
Fixing kotlin documentation

### DIFF
--- a/docs/sections/kotlin.md
+++ b/docs/sections/kotlin.md
@@ -5,12 +5,12 @@
 !!! info
     [**Kotlin**](https://kotlinlang.org/) is a modern, concise and safe programming language.
 
-The `kotlin` section displays the version of the Scala Kotlin `kotlinc -version`.
+The `kotlin` section displays the version of the Kotlin compiler `kotlinc -version`.
 
 This section is displayed only within Kotlin projects, meaning:
 
-* Contains any source files with `*.kt` extension
-* Contains any scripts with `*.kts` extensions
+* Contains any source file with `*.kt` extension
+* Contains any scripts file with `*.kts` extension
 
 ## Options
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,6 @@ nav:
         - Ruby (ruby): sections/ruby.md
         - Rust (rust): sections/rust.md
         - Scala (scala): sections/scala.md
-        - Kotlin (kotlin): sections/kotlin.md
         - Sudo (sudo): sections/sudo.md
         - Swift (swift): sections/swift.md
         - Terraform (terraform): sections/terraform.md


### PR DESCRIPTION
#### Description
* Fixed kotlin documentation
* Removed repeated `kotlin` selection in `mkdocs.yml`
