### PR TITLE
Fix Scala version detection

### DIFF
--- a/sections/scala.zsh
+++ b/sections/scala.zsh
@@ -28,7 +28,7 @@ spaceship_scala() {
   [[ -n "$is_scala_context" || -n *.scala(#qN^/) || -n *.sbt(#qN^/) ]] || return
 
   # pipe version info into stdout; won't work otherwise
-  local scala_version=$(scalac -version 2>&1 | spaceship::grep -oe "[0-9]\.[0-9]\.[0-9]")
+  local scala_version=$(scalac -version 2>&1 | spaceship::grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
 
   [[ -z "$scala_version" || "${scala_version}" == "system" ]] && return
 


### PR DESCRIPTION
Fixed Scala version detection in scala.zsh section.
Added "+" in regex. As it was before it was unable to detect versions of scala 2 from 2.10 up, for example currently newest 2.13.10