### PR TITLE
martin/fix-char-change

### DIFF
--- a/tests/char.test.zsh
+++ b/tests/char.test.zsh
@@ -27,6 +27,8 @@ setUp() {
   SPACESHIP_CHAR_COLOR_SUCCESS="green"
   SPACESHIP_CHAR_COLOR_FAILURE="red"
   SPACESHIP_CHAR_COLOR_SECONDARY="yellow"
+
+  cd $SHUNIT_TMPDIR
 }
 
 oneTimeTearDown() {
@@ -39,6 +41,8 @@ tearDown() {
   unset SPACESHIP_CHAR_PREFIX
   unset SPACESHIP_CHAR_SUFFIX
   unset SPACESHIP_CHAR_SYMBOL
+  unset SPACESHIP_CHAR_SYMBOL_SUCCESS
+  unset SPACESHIP_CHAR_SYMBOL_FAILURE
   unset SPACESHIP_CHAR_COLOR_SUCCESS
   unset SPACESHIP_CHAR_COLOR_FAILURE
   unset SPACESHIP_CHAR_COLOR_SECONDARY
@@ -48,11 +52,20 @@ tearDown() {
 # TEST CASES
 # ------------------------------------------------------------------------------
 
-test_char() {
+test_char_symbol() {
+  SPACESHIP_CHAR_SYMBOL='X '
+
+  local expected="%{%B%F{green}%}X %{%b%f%}"
+  local actual="$(spaceship::testkit::render_prompt)"
+
+  assertEquals "render char with custom symbol" "$expected" "$actual"
+}
+
+test_char_sucess() {
   SPACESHIP_CHAR_COLOR_SUCCESS=blue
   SPACESHIP_CHAR_SYMBOL_SUCCESS="S "
 
-  local expected="%{%B%F{$SPACESHIP_CHAR_COLOR_SUCCESS}%}$SPACESHIP_CHAR_SYMBOL_SUCCESS%{%b%f%}"
+  local expected="%{%B%F{blue}%}S %{%b%f%}"
   local actual="$(spaceship::testkit::render_prompt)"
 
   assertEquals "render char" "$expected" "$actual"
@@ -62,7 +75,7 @@ test_char_failure() {
   SPACESHIP_CHAR_COLOR_FAILURE=yellow
   SPACESHIP_CHAR_SYMBOL_FAILURE="F "
 
-  local expected="%{%B%F{$SPACESHIP_CHAR_COLOR_FAILURE}%}$SPACESHIP_CHAR_SYMBOL_FAILURE%{%b%f%}"
+  local expected="%{%B%F{yellow}%}F %{%b%f%}"
   command false # this command should exit with non-zero code
   local actual="$(spaceship::testkit::render_prompt)"
 
@@ -70,10 +83,10 @@ test_char_failure() {
 }
 
 test_char_prefix() {
-  SPACESHIP_CHAR_PREFIX='prefix'
+  SPACESHIP_CHAR_PREFIX='P '
   SPACESHIP_CHAR_SUFFIX=''
 
-  local expected="%{%B%}$SPACESHIP_CHAR_PREFIX%{%b%}%{%B%F{green}%}➜ %{%b%f%}"
+  local expected="%{%B%}P %{%b%}%{%B%F{green}%}➜ %{%b%f%}"
   local actual="$(spaceship::testkit::render_prompt)"
 
   assertEquals "render char with prefix" "$expected" "$actual"
@@ -81,9 +94,9 @@ test_char_prefix() {
 
 test_char_suffix() {
   SPACESHIP_CHAR_PREFIX=''
-  SPACESHIP_CHAR_SUFFIX='suffix'
+  SPACESHIP_CHAR_SUFFIX=' S'
 
-  local expected="%{%B%F{green}%}➜ %{%b%f%}%{%B%}$SPACESHIP_CHAR_SUFFIX%{%b%}"
+  local expected="%{%B%F{green}%}➜ %{%b%f%}%{%B%} S%{%b%}"
   local actual="$(spaceship::testkit::render_prompt)"
 
   assertEquals "render char with suffix" "$expected" "$actual"


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

The feature to change the default char symbol broke in this commit: ac313114c3da78d4ceb2b9b6a35822f764880e37, I'm not sure how to fix it but this test case is showing that it is broken. 

#### Screenshot

<img width="1265" alt="billede" src="https://user-images.githubusercontent.com/2058315/212625271-5f0d4c0a-99c0-4b26-bc60-2a49ebe58038.png">