### PR TITLE
Fix package maven

### DIFF
--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -106,7 +106,10 @@ spaceship_package::maven() {
   fi
   [[ -z $maven_exe ]] && return
 
-  $maven_exe help:evaluate -q -DforceStdout -D"expression=project.version" 2>/dev/null
+  local version
+  version=$($maven_exe help:evaluate -q -DforceStdout -Dexpression=project.version 2>/dev/null)
+  [[ $? != 0 ]] && return
+  echo "${version}"
 }
 
 spaceship_package::gradle() {

--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -100,7 +100,11 @@ spaceship_package::julia() {
 spaceship_package::maven() {
   spaceship::upsearch -s pom.xml || return
 
-  local maven_exe=$(spaceship::upsearch mvnw) || (spaceship::exists mvn && maven_exe="mvn") || return
+  local maven_exe=$(spaceship::upsearch mvnw)
+  if [[ -z $maven_exe ]] && spaceship::exists mvn; then
+      maven_exe="mvn"
+  fi
+  [[ -z $maven_exe ]] && return
 
   $maven_exe help:evaluate -q -DforceStdout -D"expression=project.version" 2>/dev/null
 }

--- a/tests/package_maven.test.zsh
+++ b/tests/package_maven.test.zsh
@@ -61,11 +61,12 @@ test_maven_exe_mvnw() {
   local mocked_version="2.1.0-SNAPSHOT"
   local expected="${prefix}${mocked_version}${suffix}"
   echo "printf ${mocked_version}" >> ./mvnw && chmod +x ./mvnw
-  touch pom.xml
+  local file="pom.xml"
+  touch $file
 
   actual="$(spaceship::testkit::render_prompt)"
   assertEquals "should render with $file" "$expected" "$actual"
-  rm pom.xml
+  rm $file
   rm mvnw
 }
 
@@ -75,11 +76,12 @@ test_maven_exe_mvn() {
   local mocked_version="2.1.0-SNAPSHOT"
   local expected="${prefix}${mocked_version}${suffix}"
   local mvn() { printf ${mocked_version} }
-  touch pom.xml
+  local file="pom.xml"
+  touch $file
 
   actual="$(spaceship::testkit::render_prompt)"
   assertEquals "should render with $file" "$expected" "$actual"
-  rm pom.xml
+  rm $file
 }
 
 test_maven_no_files() {
@@ -94,6 +96,20 @@ test_maven_upsearch_files() {
   local mocked_version="2.1.0-SNAPSHOT"
   local mvn() { printf ${mocked_version} }
   local expected="${prefix}${mocked_version}${suffix}"
+
+  FILES=( pom.xml )
+  for file in $FILES; do
+    touch $file
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+test_non_parseble_pom() {
+  local output="[ERROR] Some problems were encountered while processing the POMs: [FATAL] Non-parseable POM"
+  mvn() { printf ${output}; exit 1; }
+  local expected="" # empty string
 
   FILES=( pom.xml )
   for file in $FILES; do

--- a/tests/package_maven.test.zsh
+++ b/tests/package_maven.test.zsh
@@ -1,0 +1,107 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(package)
+  SPACESHIP_PACKAGE_ORDER=(maven)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_PACKAGE_SHOW="true"
+  SPACESHIP_PACKAGE_PREFIX="is "
+  SPACESHIP_PACKAGE_SUFFIX=""
+  SPACESHIP_PACKAGE_SYMBOL="📦 "
+  SPACESHIP_PACKAGE_COLOR="red"
+
+  mkdir -p "$SHUNIT_TMPDIR/.git"   # stop upsearch here
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_PACKAGE_SHOW
+  unset SPACESHIP_PACKAGE_PREFIX
+  unset SPACESHIP_PACKAGE_SUFFIX
+  unset SPACESHIP_PACKAGE_SYMBOL
+  unset SPACESHIP_PACKAGE_COLOR
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+test_maven_no_exec_found() {
+  local expected=""
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without mvn or mvnw" "$expected" "$actual"
+}
+
+test_maven_exe_mvnw() {
+  local prefix="%{%B%}${SPACESHIP_PACKAGE_PREFIX}%{%b%}%{%B%F{$SPACESHIP_PACKAGE_COLOR}%}${SPACESHIP_PACKAGE_SYMBOL}"
+  local suffix="%{%b%f%}"
+  local mocked_version="2.1.0-SNAPSHOT"
+  local expected="${prefix}${mocked_version}${suffix}"
+  echo "printf ${mocked_version}" >> ./mvnw && chmod +x ./mvnw
+  touch pom.xml
+
+  actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with $file" "$expected" "$actual"
+  rm pom.xml
+  rm mvnw
+}
+
+test_maven_exe_mvn() {
+  local prefix="%{%B%}${SPACESHIP_PACKAGE_PREFIX}%{%b%}%{%B%F{$SPACESHIP_PACKAGE_COLOR}%}${SPACESHIP_PACKAGE_SYMBOL}"
+  local suffix="%{%b%f%}"
+  local mocked_version="2.1.0-SNAPSHOT"
+  local expected="${prefix}${mocked_version}${suffix}"
+  local mvn() { printf ${mocked_version} }
+  touch pom.xml
+
+  actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with $file" "$expected" "$actual"
+  rm pom.xml
+}
+
+test_maven_no_files() {
+  local expected=""
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without files" "$expected" "$actual"
+}
+
+test_maven_upsearch_files() {
+  local prefix="%{%B%}${SPACESHIP_PACKAGE_PREFIX}%{%b%}%{%B%F{$SPACESHIP_PACKAGE_COLOR}%}${SPACESHIP_PACKAGE_SYMBOL}"
+  local suffix="%{%b%f%}"
+  local mocked_version="2.1.0-SNAPSHOT"
+  local mvn() { printf ${mocked_version} }
+  local expected="${prefix}${mocked_version}${suffix}"
+
+  FILES=( pom.xml )
+  for file in $FILES; do
+    touch $file
+    local actual="$(spaceship::testkit::render_prompt)"
+    assertEquals "should render with $file" "$expected" "$actual"
+    rm $file
+  done
+}
+
+source tests/shunit2/shunit2


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
The package maven module didn't handle non-parseable XML file (pom.xml). This could happen e.g. if you are in a middle of a merge-conflict. The maven command prints errors to stdout so we have to check the exit code.

When fixing non-parseable pom I discovered that we didn't handle the lookup for maven exe correctly so I fixed that too.

Added tests for package_maven. 
<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
