### PR TITLE
allow prettifying the kubectl context and namespace

### DIFF
--- a/docs/sections/kubectl.md
+++ b/docs/sections/kubectl.md
@@ -65,13 +65,32 @@ SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS=(
 )
 ```
 
+### Prettifying the displayed context and namespace
+
+You can furthermore alter the displayed context and namespace in functions of your own. To do so, write functions that accept the raw value in `$1` and echo the prettified version, and supply their names in the `SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT` and `SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_NAMESPACE` options, respectively.
+
+For instance, you would make production clusters stand out with:
+
+```zsh title=".zshrc"
+prettify_kubectl_context() {
+  local name="$1"
+  [[ $name = (#b)prod-(*) ]] && name="$match[1]$emoji[smiling_imp]"
+  echo $name
+}
+SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT=prettify_kubectl_context
+```
+
+(This assumes that you have Oh My Zsh's `$emoji[]` loaded, for readability.)
+
 ### Options
 
-| Variable                                   |              Default               | Meaning                                       |
-| :----------------------------------------- | :--------------------------------: | --------------------------------------------- |
-| `SPACESHIP_KUBECTL_CONTEXT_SHOW`           |               `true`               | Show subsection                               |
-| `SPACESHIP_KUBECTL_CONTEXT_PREFIX`         |               `at·`                | Subsection's prefix                           |
-| `SPACESHIP_KUBECTL_CONTEXT_SUFFIX`         | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Subsection's suffix                           |
-| `SPACESHIP_KUBECTL_CONTEXT_COLOR`          |               `cyan`               | Subsection's color                            |
-| `SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE` |               `true`               | Should namespace be also displayed            |
-| `SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS`   |                 -                  | _Array_ of pairs of colors and match patterns |
+| Variable                                       |              Default               | Meaning                                           |
+| :--------------------------------------------- | :--------------------------------: | ------------------------------------------------- |
+| `SPACESHIP_KUBECTL_CONTEXT_SHOW`               |               `true`               | Show subsection                                   |
+| `SPACESHIP_KUBECTL_CONTEXT_PREFIX`             |               `at·`                | Subsection's prefix                               |
+| `SPACESHIP_KUBECTL_CONTEXT_SUFFIX`             | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Subsection's suffix                               |
+| `SPACESHIP_KUBECTL_CONTEXT_COLOR`              |               `cyan`               | Subsection's color                                |
+| `SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE`     |               `true`               | Should namespace be also displayed                |
+| `SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS`       |                 -                  | _Array_ of pairs of colors and match patterns     |
+| `SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT`   |                 -                  | Name of function to alter the displayed context   |
+| `SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_NAMESPACE` |                 -                  | Name of function to alter the displayed namespace |

--- a/docs/sections/kubectl.md
+++ b/docs/sections/kubectl.md
@@ -87,7 +87,7 @@ SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT=prettify_kubectl_context
 | Variable                                       |              Default               | Meaning                                           |
 | :--------------------------------------------- | :--------------------------------: | ------------------------------------------------- |
 | `SPACESHIP_KUBECTL_CONTEXT_SHOW`               |               `true`               | Show subsection                                   |
-| `SPACESHIP_KUBECTL_CONTEXT_PREFIX`             |               `at·`                | Subsection's prefix                               |
+| `SPACESHIP_KUBECTL_CONTEXT_PREFIX`             |                 -                  | Subsection's prefix                               |
 | `SPACESHIP_KUBECTL_CONTEXT_SUFFIX`             | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Subsection's suffix                               |
 | `SPACESHIP_KUBECTL_CONTEXT_COLOR`              |               `cyan`               | Subsection's color                                |
 | `SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE`     |               `true`               | Should namespace be also displayed                |

--- a/sections/kubectl_context.zsh
+++ b/sections/kubectl_context.zsh
@@ -16,10 +16,23 @@ SPACESHIP_KUBECTL_CONTEXT_SUFFIX="${SPACESHIP_KUBECTL_CONTEXT_SUFFIX="$SPACESHIP
 SPACESHIP_KUBECTL_CONTEXT_COLOR="${SPACESHIP_KUBECTL_CONTEXT_COLOR="cyan"}"
 SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE="${SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE=true}"
 SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS=(${SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS=})
+SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT="${SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT=""}"
+SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_NAMESPACE="${SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_NAMESPACE=""}"
 
 # ------------------------------------------------------------------------------
 # Section
 # ------------------------------------------------------------------------------
+
+spaceship_kubectl_prettify() {
+  local prettify_fn=$1
+  local what=$2
+
+  if [[ -n $prettify_fn ]]; then
+    $prettify_fn $what
+  else
+    echo $what
+  fi
+}
 
 # Show current context in kubectl
 spaceship_kubectl_context() {
@@ -30,9 +43,19 @@ spaceship_kubectl_context() {
   local kube_context=$(kubectl config current-context 2>/dev/null)
   [[ -z $kube_context ]] && return
 
+  local kube_context_pretty=$(spaceship_kubectl_prettify "$SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_CONTEXT" $kube_context)
+
   if [[ $SPACESHIP_KUBECTL_CONTEXT_SHOW_NAMESPACE == true ]]; then
     local kube_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)
-    [[ -n $kube_namespace && "$kube_namespace" != "default" ]] && kube_context="$kube_context ($kube_namespace)"
+
+    if [[ -n $kube_namespace ]]; then
+      local kube_namespace_pretty=$(spaceship_kubectl_prettify "$SPACESHIP_KUBECTL_CONTEXT_PRETTIFY_NAMESPACE" $kube_namespace)
+
+      if [[ "$kube_namespace" != "default" ]]; then
+        kube_context="$kube_context ($kube_namespace)"
+        kube_context_pretty="$kube_context_pretty ($kube_namespace_pretty)"
+      fi
+    fi
   fi
 
   # Apply custom color to section if $kube_context matches a pattern defined in SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS array.
@@ -56,5 +79,5 @@ spaceship_kubectl_context() {
     --color "$section_color" \
     --prefix "$SPACESHIP_KUBECTL_CONTEXT_PREFIX" \
     --suffix "$SPACESHIP_KUBECTL_CONTEXT_SUFFIX" \
-    "$kube_context"
+    "$kube_context_pretty"
 }


### PR DESCRIPTION
#### Description

This allows further customization of the displayed context and namespace in the kubectl section.

Use cases: shortening ugly context names maintained by integration tools, adding Unicode candy etc.

It adds two configuration options that may point to functions that will rewrite the context and namespace. See the updated documentation below for more information.

I've used a second set of `kube_xxx_pretty` variables for the prettified names. This keeps `SPACESHIP_KUBECTL_CONTEXT_COLOR_GROUPS` unchanged, even when used together with the prettifying functions.

I also stumbled upon some outdated documentation, so I bundled a trivial commit for it in the PR. I hope it's OK.

#### Screenshot

![image](https://user-images.githubusercontent.com/2720284/215888586-6d6767ba-0c17-46f8-b1dd-00f80ff54741.png)

(This demonstrates Unicode eyecandy only: my real, ugly context names have too much customer information.)
