### PR TITLE
Pulumi section should match on the currently selected stack

### DIFF
--- a/sections/pulumi.zsh
+++ b/sections/pulumi.zsh
@@ -31,7 +31,7 @@ spaceship_pulumi() {
   local pulumi_project=$(spaceship::upsearch Pulumi.y*ml)
   [[ -n "$pulumi_project" || -d .pulumi/stacks ]] || return
 
-  local pulumi_stack=$(pulumi stack ls 2>/dev/null | sed -n -e '/\x2A/p' | cut -f1 -d" " | sed s/\*//
+  local pulumi_stack=$(pulumi stack ls 2>/dev/null | sed -n -e '/\x2A/p' | cut -f1 -d" " | sed s/\*//)
   [[ -z $pulumi_stack ]] && return
 
   spaceship::section \

--- a/sections/pulumi.zsh
+++ b/sections/pulumi.zsh
@@ -31,7 +31,7 @@ spaceship_pulumi() {
   local pulumi_project=$(spaceship::upsearch Pulumi.y*ml)
   [[ -n "$pulumi_project" || -d .pulumi/stacks ]] || return
 
-  local pulumi_stack=$(pulumi stack ls 2>/dev/null | sed -n -e '2p' | cut -f1 -d" " | sed s/\*//)
+  local pulumi_stack=$(pulumi stack ls 2>/dev/null | sed -n -e '/\x2A/p' | cut -f1 -d" " | sed s/\*//
   [[ -z $pulumi_stack ]] && return
 
   spaceship::section \


### PR DESCRIPTION
#### Description

The pulumi section currently uses `sed` to select the second line from the `pulumi stack ls` command and then performs some operations to trim that to yield the stack name. Unfortunately, the selected stack doesn't default to the 2nd line unless there's only 1 stack.

Instead, the selected stack will always have an asterisk at the end of it
```
NAME                    LAST UPDATE   RESOURCE COUNT  URL
organization/dev          2 hours ago   58              https://app.pulumi.com/organization/project/dev
organization/dev-bill     1 month ago   44              https://app.pulumi.com/organization/project/dev-bill
organization/dev-ted      1 week ago    58              https://app.pulumi.com/organization/project/dev-ted
organization/dev-chris    2 months ago  29              https://app.pulumi.com/organization/project/dev-chris
organization/dev-frank    3 days ago    58              https://app.pulumi.com/organization/project/dev-frank
organization/dev-pat*     2 days ago    58              https://app.pulumi.com/organization/project/dev-pat
organization/dev-jeff     1 month ago   44              https://app.pulumi.com/organization/project/dev-jeff
organization/prod         1 week ago    58              https://app.pulumi.com/organization/project/prod
organization/qa           18 hours ago  58              https://app.pulumi.com/organization/project/qa
```

We can see here that `project/dev-pat` is the currently selected stack, but with the current logic spaceship would return `project/dev`

#### Solution
Update the `sed` expression to find the line with the asterisk, then perform the trimming operations

Before:
```
➜ pulumi stack ls 2>/dev/null | sed -n -e '2p' | cut -f1 -d" " | sed s/\*//
project/dev
```

After:
```
➜ pulumi stack ls 2>/dev/null | sed -n -e '/\x2A/p' | cut -f1 -d" " | sed s/\*//
project/dev-pat
```
