### PR TITLE
prompt typo - not escaping the }

### DIFF
--- a/lib/prompts.zsh
+++ b/lib/prompts.zsh
@@ -15,7 +15,7 @@ spaceship::prompt() {
 
   # Allow iTerm integration to work
   if [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]]; then
-    prompt="%{$(iterm2_prompt_mark)%}${prompt}%{$(iterm2_prompt_end)}"
+    prompt="%{$(iterm2_prompt_mark)%}${prompt}%{$(iterm2_prompt_end)%}"
   fi
 
   # Should it add a new line before the prompt?
@@ -55,7 +55,6 @@ spaceship::ps2() {
   local ps2="$(spaceship::section --color "$SPACESHIP_CHAR_COLOR_SECONDARY" "$char")"
   spaceship::section::render "$ps2"
 }
-
 
 # Render the prompt. Compose variables using prompt functoins.
 # USAGE:


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description
Prompt.zsh file had a typo that would result in a `}` being left on the command line. this is due to the portion of the code
```shell
 if [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-}" == "Yes" ]]; then
    prompt="%{$(iterm2_prompt_mark)%}${prompt}%{$(iterm2_prompt_end)%}" # right here there was the '%' missing before the closing '}'
  fi
  ```
<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot
<img width="386" alt="Screenshot 2023-05-05 at 16 23 00" src="https://user-images.githubusercontent.com/18503099/236485125-c8f7bf4f-fb45-4e0a-988d-bbc76b116fc1.png">

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
