### PR TITLE
fix(rprompt): Missing the first prefix of first section in right prom…

### DIFF
--- a/lib/prompts.zsh
+++ b/lib/prompts.zsh
@@ -30,6 +30,8 @@ spaceship::prompt() {
 # RPROMPT
 # Optional (right) prompt
 spaceship::rprompt() {
+  _spaceship_prompt_opened="$SPACESHIP_PROMPT_FIRST_PREFIX_SHOW"
+  
   # Compose prompt from the order
   local rprompt="$(spaceship::core::compose_order $SPACESHIP_RPROMPT_ORDER)"
 


### PR DESCRIPTION
#### Description

this PR is about the issue https://github.com/spaceship-prompt/spaceship-prompt/issues/1179

#### Screenshot

Previously, like this

<img width="920" alt="image" src="https://github.com/spaceship-prompt/spaceship-prompt/assets/16741164/129dc6f5-18f1-45ca-9dcd-591fb75910d2">

and now,

<img width="917" alt="image" src="https://github.com/spaceship-prompt/spaceship-prompt/assets/16741164/826f6b98-3928-4e5a-a924-02dbcc8df52f">
