### PR TITLE
Update docker compose section for compose v2

### DIFF
--- a/sections/docker_compose.zsh
+++ b/sections/docker_compose.zsh
@@ -43,7 +43,7 @@ spaceship_docker_compose() {
   local statuses=""
 
   while IFS= read -r line; do
-    local letter_position=$(echo $line | awk 'match($0,"_"){print RSTART}')
+    local letter_position=$(echo $line | awk 'match($0,"_|-"){print RSTART}')
     local letter=$(echo ${line:$letter:1} | tr '[:lower:]' '[:upper:]')
     local color=""
     [[ -z "$letter" ]] && continue


### PR DESCRIPTION
#### Description

Docker Compose v2 uses a `-` instead of the `_` used by Compose v1. This update allows the section to properly detect the container name of containers started by Compose v2 by updating the `awk` match from `_` to `_|-` so it can split on either underscore or dash.
