### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: semantic
         with:
           extra_plugins: |
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/changelog
             @semantic-release/git
             semantic-release-license

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
         "path": "LICENSE.md"
       }
     }],
-    ["@google/semantic-release-replace-plugin", {
+    ["semantic-release-replace-plugin", {
       "replacements": [{
         "files": ["spaceship.zsh"],
         "from": "export SPACESHIP_VERSION='.*'",


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).