### PR TITLE
Add  i386 section to external sections

### DIFF
--- a/docs/registry/external.json
+++ b/docs/registry/external.json
@@ -2,6 +2,11 @@
   "$schema": "./schema.json",
   "sections": [
     {
+      "name": "arch",
+      "url": "https://github.com/windwhinny/spaceship-arch",
+      "description": "The arch section for Spaceship prompt shows if current shell running in x86 env."
+    },
+    {
       "name": "vi_mode",
       "url": "https://github.com/spaceship-prompt/spaceship-vi-mode",
       "description": "Vi-mode section for Spaceship prompt."


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

add a external space ship section.

The arch section shows i386 if current shell running in x86 env on macOS. Otherwise it will hide by default.

#### Screenshot

![alt screenshot](https://github.com/windwhinny/spaceship-arch/blob/main/assets/screenshot.png?raw=true)
