### PR TITLE
Better AWS Section and a spacing issue fix for Kube Section

### DIFF
--- a/docs/sections/aws.de.md
+++ b/docs/sections/aws.de.md
@@ -9,10 +9,15 @@ If the `AWS_VAULT` variable is not defined, this section will use the [`AWS_PROF
 
 ## Options
 
-| Variable               |              Default               | Meaning                             |
-|:---------------------- |:----------------------------------:| ----------------------------------- |
-| `SPACESHIP_AWS_SHOW`   |               `true`               | Show section                        |
-| `SPACESHIP_AWS_PREFIX` |              `using·`              | Section's prefix                    |
-| `SPACESHIP_AWS_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
-| `SPACESHIP_AWS_SYMBOL` |               `☁️·`                | Symbol displayed before the section |
-| `SPACESHIP_AWS_COLOR`  |               `208`                | Section's color                     |
+| Variable                             |              Default               | Meaning                             |
+| :----------------------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_AWS_SHOW`                 |               `true`               | Show section                        |
+| `SPACESHIP_AWS_PREFIX`               |              `using·`              | Section's prefix                    |
+| `SPACESHIP_AWS_SUFFIX`               | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_AWS_SYMBOL`               |               `☁️·`                 | Symbol displayed before the section |
+| `SPACESHIP_AWS_COLOR`                |               `208`                | Section's color                     |
+| `SPACESHIP_AWS_PROFILE_SHOW`         |               `true`               | Show current set Profile            |
+| `SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW`   |               `true`               | Show current account alias          |
+| `SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW`  |               `true`               | Show current account number         |
+| `SPACESHIP_AWS_ACCOUNT_ROLE_SHOW`    |               `true`               | Show current role being used        |
+| `SPACESHIP_AWS_ACCOUNT_SESSION_SHOW` |               `true`               | Show current session name           |

--- a/docs/sections/aws.fr.md
+++ b/docs/sections/aws.fr.md
@@ -9,10 +9,15 @@ If the `AWS_VAULT` variable is not defined, this section will use the [`AWS_PROF
 
 ## Options
 
-| Variable               |              Default               | Meaning                             |
-|:---------------------- |:----------------------------------:| ----------------------------------- |
-| `SPACESHIP_AWS_SHOW`   |               `true`               | Show section                        |
-| `SPACESHIP_AWS_PREFIX` |              `using·`              | Section's prefix                    |
-| `SPACESHIP_AWS_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
-| `SPACESHIP_AWS_SYMBOL` |               `☁️·`                | Symbol displayed before the section |
-| `SPACESHIP_AWS_COLOR`  |               `208`                | Section's color                     |
+| Variable                             |              Default               | Meaning                             |
+| :----------------------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_AWS_SHOW`                 |               `true`               | Show section                        |
+| `SPACESHIP_AWS_PREFIX`               |              `using·`              | Section's prefix                    |
+| `SPACESHIP_AWS_SUFFIX`               | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_AWS_SYMBOL`               |               `☁️·`                 | Symbol displayed before the section |
+| `SPACESHIP_AWS_COLOR`                |               `208`                | Section's color                     |
+| `SPACESHIP_AWS_PROFILE_SHOW`         |               `true`               | Show current set Profile            |
+| `SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW`   |               `true`               | Show current account alias          |
+| `SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW`  |               `true`               | Show current account number         |
+| `SPACESHIP_AWS_ACCOUNT_ROLE_SHOW`    |               `true`               | Show current role being used        |
+| `SPACESHIP_AWS_ACCOUNT_SESSION_SHOW` |               `true`               | Show current session name           |

--- a/docs/sections/aws.md
+++ b/docs/sections/aws.md
@@ -1,7 +1,7 @@
 # Amazon Web Services (AWS) `aws`
 
 !!! info
-    [**Amazon Web Services (AWS)**](https://aws.amazon.com) provides on-demand cloud computing platforms and APIs to individuals, companies, and governments, on a metered pay-as-you-go basis.
+[**Amazon Web Services (AWS)**](https://aws.amazon.com) provides on-demand cloud computing platforms and APIs to individuals, companies, and governments, on a metered pay-as-you-go basis.
 
 The `aws` section shows the current AWS profile using the [`AWS_VAULT`](https://github.com/99designs/aws-vault) environment variable.
 
@@ -9,10 +9,15 @@ If the `AWS_VAULT` variable is not defined, this section will use the [`AWS_PROF
 
 ## Options
 
-| Variable               |              Default               | Meaning                             |
-| :--------------------- | :--------------------------------: | ----------------------------------- |
-| `SPACESHIP_AWS_SHOW`   |               `true`               | Show section                        |
-| `SPACESHIP_AWS_PREFIX` |              `using·`              | Section's prefix                    |
-| `SPACESHIP_AWS_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
-| `SPACESHIP_AWS_SYMBOL` |               `☁️·`                | Symbol displayed before the section |
-| `SPACESHIP_AWS_COLOR`  |               `208`                | Section's color                     |
+| Variable                             |              Default               | Meaning                             |
+| :----------------------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_AWS_SHOW`                 |               `true`               | Show section                        |
+| `SPACESHIP_AWS_PREFIX`               |              `using·`              | Section's prefix                    |
+| `SPACESHIP_AWS_SUFFIX`               | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_AWS_SYMBOL`               |               `☁️·`                 | Symbol displayed before the section |
+| `SPACESHIP_AWS_COLOR`                |               `208`                | Section's color                     |
+| `SPACESHIP_AWS_PROFILE_SHOW`         |               `true`               | Show current set Profile            |
+| `SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW`   |               `true`               | Show current account alias          |
+| `SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW`  |               `true`               | Show current account number         |
+| `SPACESHIP_AWS_ACCOUNT_ROLE_SHOW`    |               `true`               | Show current role being used        |
+| `SPACESHIP_AWS_ACCOUNT_SESSION_SHOW` |               `true`               | Show current session name           |

--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -51,12 +51,11 @@ spaceship_aws() {
     if [[ -z $account_alias ]] || [[ "$account_alias" == "error" ]]; then
       aws_info="${aws_info}"
     else
-      if [[ $SPACESHIP_AWS_PROFILE_SHOW == true ]] && ( [[ -z $profile ]] || [[ "$profile" == "error" ]]); then
+      if [[ $SPACESHIP_AWS_PROFILE_SHOW == false ]] || ( [[ -z $profile ]] || [[ "$profile" == "error" ]]); then
         aws_info="${aws_info} ${account_alias}"
       else
         aws_info="${aws_info}:${account_alias}"
       fi
-      
     fi
   fi
   if [[ $SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW == true ]]; then

--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -9,7 +9,12 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_AWS_SHOW="${SPACESHIP_AWS_SHOW=true}"
-SPACESHIP_AWS_ASYNC="${SPACESHIP_AWS_ASYNC=false}"
+SPACESHIP_AWS_PROFILE_SHOW="${SPACESHIP_AWS_PROFILE_SHOW=true}"
+SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW="${SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW=true}"
+SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW="${SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW=true}"
+SPACESHIP_AWS_ACCOUNT_ROLE_SHOW="${SPACESHIP_AWS_ACCOUNT_ROLE_SHOW=true}"
+SPACESHIP_AWS_ACCOUNT_SESSION_SHOW="${SPACESHIP_AWS_ACCOUNT_SESSION_SHOW=true}"
+SPACESHIP_AWS_ASYNC="${SPACESHIP_AWS_ASYNC=true}"
 SPACESHIP_AWS_PREFIX="${SPACESHIP_AWS_PREFIX="using "}"
 SPACESHIP_AWS_SUFFIX="${SPACESHIP_AWS_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_AWS_SYMBOL="${SPACESHIP_AWS_SYMBOL="☁️ "}"
@@ -23,10 +28,70 @@ SPACESHIP_AWS_COLOR="${SPACESHIP_AWS_COLOR="208"}"
 spaceship_aws() {
   [[ $SPACESHIP_AWS_SHOW == false ]] && return
 
-  local profile=${AWS_VAULT:-$AWS_PROFILE}
+  local aws_info=""
+  
 
-  # Is the current profile not the default profile
-  [[ -z $profile ]] || [[ "$profile" == "default" ]] && return
+  if [[ $SPACESHIP_AWS_PROFILE_SHOW == true ]]; then
+    # Get currently set profile from export or assume default
+    local profile=$(export | grep AWS_PROFILE | awk -F "=" '{print $2}' || "default")
+    # If cistom profile is not set or is default
+    if [[ -z $profile ]] || [[ "$profile" == "default" ]]; then
+      aws_info="${aws_info}"
+    else
+      aws_info="${aws_info} ${profile}"
+    fi
+  fi
+
+  if [[ $SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW == true ]] || [[ $SPACESHIP_AWS_ACCOUNT_ROLE_SHOW == true ]] || [[ $SPACESHIP_AWS_ACCOUNT_SESSION_SHOW == true ]]; then
+    local caller_identity=""
+    if [[ -z $profile ]] || [[ "$profile" == "default" ]]; then
+      caller_identity=$(aws sts get-caller-identity --query "Arn" --output text || "error")
+    fi
+  fi
+
+  if [[ $SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW == true ]]; then
+    local account_alias=$(aws iam list-account-aliases --query "AccountAliases[0]" --output text || "error")
+    if [[ -z $account_alias ]] || [[ "$account_alias" == "error" ]]; then
+      aws_info="${aws_info}"
+    else
+      if [[ $SPACESHIP_AWS_PROFILE_SHOW == true ]] && ( [[ -z $profile ]] || [[ "$profile" == "error" ]]); then
+        aws_info="${aws_info} ${account_alias}"
+      else
+        aws_info="${aws_info}:${account_alias}"
+      fi
+      
+    fi
+  fi
+  if [[ $SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW == true ]]; then
+    local account_number=$(echo $caller_identity | awk -F ":" '{print $5}' || "error")
+    if [[ -z $account_number ]] || [[ "$account_number" == "error" ]]; then
+      aws_info="${aws_info}"
+    else
+      aws_info="${aws_info}[${account_number}]"
+    fi
+  fi
+  if [[ $SPACESHIP_AWS_ACCOUNT_ROLE_SHOW == true ]]; then
+    local account_role=$(echo $caller_identity | awk -F "/" '{print $2}' || "error")
+    if [[ -z $account_role ]] || [[ "$account_role" == "error" ]]; then
+      aws_info="${aws_info}"
+    else
+      aws_info="${aws_info}/${account_role}"
+    fi
+  fi
+  if [[ $SPACESHIP_AWS_ACCOUNT_SESSION_SHOW == true ]]; then
+    local account_session=$(echo $caller_identity | awk -F "/" '{print $3}' || "error")
+    if [[ -z $account_session ]] || [[ "$account_session" == "error" ]]; then
+      aws_info="${aws_info}"
+    else
+      if [[ $SPACESHIP_AWS_ACCOUNT_ROLE_SHOW == true ]] && ( [[ -z $account_role ]] || [[ "$account_role" == "error" ]]); then
+        aws_info="${aws_info} ${account_session}"
+      else
+        aws_info="${aws_info}/${account_session}"
+      fi
+    fi
+  fi
+  
+  [[ -z $aws_info ]] || [[ "$aws_info" == "" ]] && SPACESHIP_AWS_SYMBOL="" && return
 
   # Show prompt section
   spaceship::section \
@@ -34,5 +99,5 @@ spaceship_aws() {
     --prefix "$SPACESHIP_AWS_PREFIX" \
     --suffix "$SPACESHIP_AWS_SUFFIX" \
     --symbol "$SPACESHIP_AWS_SYMBOL" \
-    "$profile"
+    "$aws_info"
 }

--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -43,10 +43,7 @@ spaceship_aws() {
   fi
 
   if [[ $SPACESHIP_AWS_ACCOUNT_NUMBER_SHOW == true ]] || [[ $SPACESHIP_AWS_ACCOUNT_ROLE_SHOW == true ]] || [[ $SPACESHIP_AWS_ACCOUNT_SESSION_SHOW == true ]]; then
-    local caller_identity=""
-    if [[ -z $profile ]] || [[ "$profile" == "default" ]]; then
-      caller_identity=$(aws sts get-caller-identity --query "Arn" --output text || "error")
-    fi
+    local caller_identity=$(aws sts get-caller-identity --query "Arn" --output text || "error")
   fi
 
   if [[ $SPACESHIP_AWS_ACCOUNT_ALIAS_SHOW == true ]]; then

--- a/sections/aws.zsh
+++ b/sections/aws.zsh
@@ -33,7 +33,7 @@ spaceship_aws() {
 
   if [[ $SPACESHIP_AWS_PROFILE_SHOW == true ]]; then
     # Get currently set profile from export or assume default
-    local profile=$(export | grep AWS_PROFILE | awk -F "=" '{print $2}' || "default")
+    local profile=$(export | grep "AWS_PROFILE=" | awk -F "=" '{print $2}' || "default")
     # If cistom profile is not set or is default
     if [[ -z $profile ]] || [[ "$profile" == "default" ]]; then
       aws_info="${aws_info}"

--- a/sections/kubectl.zsh
+++ b/sections/kubectl.zsh
@@ -31,6 +31,8 @@ spaceship::precompile "$SPACESHIP_ROOT/sections/kubectl_context.zsh"
 #   spaceship_kubectl_version
 #   spaceship_kubectl_context
 spaceship_kubectl() {
+  local kubectl_info=""
+
   [[ $SPACESHIP_KUBECTL_SHOW == false ]] && return
 
   local kubectl_version="$(spaceship_kubectl_version)"
@@ -41,10 +43,16 @@ spaceship_kubectl() {
   local kubectl_version_section="$(spaceship::section::render $kubectl_version)"
   local kubectl_context_section="$(spaceship::section::render $kubectl_context)"
 
+  if [[ $kubectl_version_section == "" ]]; then # Fixes spacing issue if kubectl version is set to not show
+    kubectl_info="${kubectl_version_section} ${kubectl_context_section}"
+  else
+    kubectl_info="${kubectl_version_section}${kubectl_context_section}"
+  fi
+
   spaceship::section \
     --color "$SPACESHIP_KUBECTL_COLOR" \
     --prefix "$SPACESHIP_KUBECTL_PREFIX" \
     --suffix "$SPACESHIP_KUBECTL_SUFFIX" \
     --symbol "$SPACESHIP_KUBECTL_SYMBOL" \
-    "${kubectl_version_section}${kubectl_context_section}"
+    "${kubectl_info}"
 }


### PR DESCRIPTION
#### Description

1. Updated AWS Section to properly pull the current AWS_PROFILE and added options to show:
  - Account alias
  - Account number
  - Current role name
  - Current session name
2. Fixed a spacing issue with the kubectl section where if kube version was set to not showing there was no space between the icon and the kube context text.

#### Screen Shots

Here are a couple of screenshots

##### Default profile with all options on

![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/1483834/a2947213-b5e8-4d8e-84f1-5a1d83313fb6)

##### Other profile with all options on

![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/1483834/abe3b39d-027e-40f9-be99-4e7fa6008a26)

##### Default profile with account number and session name disabled

![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/1483834/f1dd3cc2-b767-47ec-8ea8-02220f946eb0)
