### PR TITLE
fix(node): getting only the node version in output

### DIFF
--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -42,6 +42,9 @@ spaceship_node() {
     return
   fi
 
+  # Get only the version
+  node_version=$(echo "$node_version" | grep -o 'v[0-9.]*' | head -n 1)
+
   # Do not show system or default versions
   [[ $node_version == "system" || $node_version == "node" ]] && return
   [[ $node_version == $SPACESHIP_NODE_DEFAULT_VERSION ]] && return

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -43,7 +43,7 @@ spaceship_node() {
   fi
 
   # Get only the version
-  node_version=$(echo "$node_version" | grep -o 'v[0-9.]*' | head -n 1)
+  node_version=$(echo "$node_version" | spaceship::grep -oE 'v[0-9.]*' | head -n 1)
 
   # Do not show system or default versions
   [[ $node_version == "system" || $node_version == "node" ]] && return


### PR DESCRIPTION
#### Description
The node section appears to show the entire output of `node -v`, resulting in:
![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/58455029/fe6ae0c1-67eb-46a4-af71-ee3822286a9a)
![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/58455029/0d992cc3-4fd7-49d4-b847-6900ffbebbb1)

Now we filter the output before
![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/58455029/9b6cee13-464f-488a-a389-c195a6ed27d0)
