### PR TITLE
Fix of the 404 for https://spaceship-prompt.sh/en/

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,7 +150,7 @@ extra:
   alternate:
     - name: English
       lang: en
-      link: /en/
+      link: .
     - name: Deutsch
       lang: de
       link: /de/


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

This PR fix the issue with none existing https://spaceship-prompt.sh/en/ URL. After upgrading `mkdocs-static-i18n` to 1.0.x the plugin does not create `/xx/` language folder for default language.

Fix of the https://github.com/spaceship-prompt/spaceship-prompt/discussions/1397.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) 
<img width="806" alt="image" src="https://github.com/spaceship-prompt/spaceship-prompt/assets/369696/8f141184-c7b3-4995-bbe3-53d2a262ab83"> -->

<img width="806" alt="image" src="https://github.com/spaceship-prompt/spaceship-prompt/assets/369696/8307e9b5-4bf3-4c7a-aae1-353e91b007e1">

