### PR TITLE
README: correct link to Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Spaceship works well out of the box, but you can customize almost everything if 
 - [**⚙️ Configuration**](https://spaceship-prompt.sh/config/intro) — Tweak section's behavior with tons of options.
 - [**😎 Advanced Usage**](https://spaceship-prompt.sh/advanced/creating-section) — Learn how to create a custom section, benefit of per-directory configuration and more.
 
-Additionally, join our community in [Discord](https://discord.gg/NTQWz8Dyt9) and follow our [Twitter](https//twitter.com/SpaceshipPrompt) for updates.
+Additionally, join our community in [Discord](https://discord.gg/NTQWz8Dyt9) and follow our [Twitter](https://twitter.com/SpaceshipPrompt) for updates.
 
 ## 🫶 Contributing
 


### PR DESCRIPTION
#### Description

One of the Twitter URLs was incorrect with the browser considering it a relative URL, sending people to a 404 GitHub error page.

This adds the `:`.