### PR TITLE
Fix Async Behavior is Freezing in Some Terminal

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -11,6 +11,9 @@
 typeset -g ASYNC_VERSION=1.8.6
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
+# Add sleep duration to give a leeway time for some terminal that haven't load
+# all the necessary script when the async job is being dispatch.
+typeset -g ASYNC_SLEEP_DURATION=${ASYNC_SLEEP_DURATION=0}
 
 # Execute commands that can manipulate the environment inside the async worker. Return output via callback.
 _async_eval() {
@@ -27,6 +30,8 @@ _async_eval() {
 _async_job() {
 	# Disable xtrace as it would mangle the output.
 	setopt localoptions noxtrace
+
+  sleep $ASYNC_SLEEP_DURATION
 
 	# Store start time for job.
 	float -F duration=$EPOCHREALTIME

--- a/lib/worker.zsh
+++ b/lib/worker.zsh
@@ -8,6 +8,8 @@
 # Unique array of async jobs
 typeset -ahU SPACESHIP_JOBS=()
 
+ASYNC_SLEEP_DURATION="${SPACESHIP_ASYNC_SLEEP_DURATION=0}"
+
 # Load zsh-async if not loaded yet
 spaceship::worker::load() {
   if ! (( ASYNC_INIT_DONE )); then


### PR DESCRIPTION
# Still Work in Progress!
Since we are using Github-Action to sync the `async.zsh` from https://github.com/mafredri/zsh-async. I'm still waiting for the https://github.com/mafredri/zsh-async/pull/67 PR to be merged (If the contributor allowed it)

# Description
Add another configurable ENV called `SPACESHIP_ASYNC_SLEEP_DURATION`. This ENV will give a leeway sleep duration can help some terminals that can't run async status properly. 

This fix issue for:
- #1368
- #1356
- #1359
- #1330
- #1193
