### PR TITLE
Utilize mkdocs-static-i18n to create language switcher

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,25 +147,6 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
 
 extra:
-  alternate:
-    - name: English
-      lang: en
-      link: .
-    - name: Deutsch
-      lang: de
-      link: /de/
-    - name: Français
-      lang: fr
-      link: /fr/
-    - name: Українська
-      lang: uk
-      link: /uk/
-    - name: 简体中文
-      lang: zh
-      link: /zh/
-    - name: Help translating
-      lang: null
-      link: https://translate.spaceship-prompt.sh/
   analytics:
     provider: google
     property: G-0STBM9BNC1
@@ -243,3 +224,6 @@ plugins:
         - locale: zh
           name: 简体中文
           build: true
+        - locale: "null" 
+          name: Help translating
+          fixed_link: https://translate.spaceship-prompt.sh/


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

This PR allows you to use the capabilities of `mkdocs-static-i18n` 1.1.0 to create a language switcher without duplicating the list of languages in `extra.alternate`. See [Adding a special item in the language switcher](https://ultrabug.github.io/mkdocs-static-i18n/setup/setting-up-material/#adding-a-special-item-in-the-language-switcher)

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
