### PR TITLE
fix,tests: Improve search for Pulumi.yml and Pulumi.yaml to prevent 'not found' message; Add tests for Pulumi section

### DIFF
--- a/sections/pulumi.zsh
+++ b/sections/pulumi.zsh
@@ -27,8 +27,8 @@ spaceship_pulumi() {
 
   spaceship::exists pulumi || return
 
-  # Show PULUMI Stack when exists
-  local pulumi_project=$(spaceship::upsearch Pulumi.y*ml)
+  # Show PULUMI Stack when exist
+  local pulumi_project="$(spaceship::upsearch Pulumi.yml Pulumi.yaml)"
   [[ -n "$pulumi_project" || -d .pulumi/stacks ]] || return
 
   local pulumi_stack=$(pulumi stack ls 2>/dev/null | sed -n -e '/\x2A/p' | cut -f1 -d" " | sed s/\*//)

--- a/tests/pulumi.test.zsh
+++ b/tests/pulumi.test.zsh
@@ -1,0 +1,86 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(pulumi)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_PULUMI_SHOW="true"
+  SPACESHIP_PULUMI_ASYNC="true"
+  SPACESHIP_PULUMI_PREFIX="via "
+  SPACESHIP_PULUMI_SUFFIX=""
+  SPACESHIP_PULUMI_SYMBOL=" "
+  SPACESHIP_PULUMI_COLOR="133"
+
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_PULUMI_SHOW
+  unset SPACESHIP_PULUMI_ASYNC
+  unset SPACESHIP_PULUMI_PREFIX
+  unset SPACESHIP_PULUMI_SUFFIX
+  unset SPACESHIP_PULUMI_SYMBOL
+  unset SPACESHIP_PULUMI_COLOR
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_pulumi_no_files() {
+  local no_files_expected=""
+  local no_files_actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without files" "$no_files_expected" "$no_files_actual"
+}
+
+test_pulumi_file_with_yaml() {
+  touch Pulumi.yaml
+  touch Pulumi.dev.yml
+
+  local yaml_expected="%{%B%}via %{%b%}%{%B%F{133}%} dev%{%b%f%}"
+  local yaml_actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with Pulumi.yaml" "$yaml_expected" "$yaml_actual"
+
+  rm Pulumi.yaml
+}
+
+test_pulumi_file_with_yml() {
+  touch Pulumi.yml
+  touch Pulumi.dev.yml
+
+  local yml_expected="%{%B%}via %{%b%}%{%B%F{133}%} dev%{%b%f%}"
+  local yml_actual="$(spaceship::testkit::render_prompt)"
+
+  assertEquals "should render with Pulumi.yml" "$yml_expected" "$yml_actual"
+
+  rm Pulumi.yml
+}
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source tests/shunit2/shunit2

--- a/tests/stubs/pulumi
+++ b/tests/stubs/pulumi
@@ -1,0 +1,6 @@
+#!/usr/bin/env zsh
+
+echo "NAME  LAST UPDATE  RESOURCE COUNT  URL"
+echo "dev*  2 weeks ago  0               https://app.pulumi.com/ORG/REPO/dev"
+echo "prod  1 day ago    178             https://app.pulumi.com/ORG/REPO/prod"
+echo "stag  1 day ago    183             https://app.pulumi.com/ORG/REPO/stag"


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

With the current version of the Pulumi section each time that I arrive at a folder without the Pulumi.y*ml file the console adds an unneeded message `spaceship_pulumi:6: no matches found: Pulumi.y*ml`.

On this PR I improved the Pulumi search file since YAML only has two possible extensions `.yml` & `.yaml`; also I added test for this section.


#### Screenshot
![CleanShot 2024-01-06 at 21 30 33](https://github.com/spaceship-prompt/spaceship-prompt/assets/6563162/7c31a1c0-ee79-4ad6-9b13-3741d9d50594)

#### Tests passing
![CleanShot 2024-01-06 at 21 35 51](https://github.com/spaceship-prompt/spaceship-prompt/assets/6563162/53e5e2d3-96d0-46af-b4ee-8068cc8e9e92)

