### PR TITLE
[docker-compose] include stopped containers

### DIFF
--- a/sections/docker_compose.zsh
+++ b/sections/docker_compose.zsh
@@ -37,7 +37,7 @@ spaceship_docker_compose() {
   spaceship::exists docker-compose || return
   spaceship::upsearch -s 'docker-compose.y*ml' || return
 
-  local containers="$(docker-compose ps 2>/dev/null | tail -n+2)"
+  local containers="$(docker-compose ps -a 2>/dev/null | tail -n+2)"
   [[ -n "$containers" ]] || return
 
   local statuses=""


### PR DESCRIPTION
Currently plugin only lists running containers. In the example bellow`elasticsearch` isn't running at first, then I start it and letter `E` shows up:
![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/16747951/91564cb2-ace3-47b6-8f65-afd44d3b7e0f)
However I personally expected this behaviour instead:
![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/16747951/2576da7f-db21-4940-9797-97196a423d22)
If container is not running it is being displayed, but in red.
