### PR TITLE
fix: --short arg in kubectl cmd does not exist in later versions

### DIFF
--- a/sections/kubectl_version.zsh
+++ b/sections/kubectl_version.zsh
@@ -31,7 +31,7 @@ spaceship_kubectl_version() {
   [[ -z $kube_context ]] && return
 
   # if kubectl can't connect kubernetes cluster, kubernetes version section will be not shown
-  local kubectl_version=$(kubectl version --short 2>/dev/null | grep "Server Version" | sed 's/Server Version: \(.*\)/\1/')
+  local kubectl_version=$(kubectl version>/dev/null | grep "Server Version" | sed 's/Server Version: \(.*\)/\1/')
   [[ -z $kubectl_version ]] && return
 
   spaceship::section \


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

kubectl version --short is now the default since >=1.28, and the arg has been removed.

#### Screenshot

Please see: https://github.com/kubernetes/kubernetes/issues/122455#issuecomment-1942718301
