### PR TITLE
Update external.json - spaceship-ip section

### DIFF
--- a/docs/registry/external.json
+++ b/docs/registry/external.json
@@ -2,6 +2,11 @@
   "$schema": "./schema.json",
   "sections": [
     {
+      "name": "ip",
+      "url": "https://github.com/TheArqsz/spaceship-ip",
+      "description": "A section for Spaceship prompt to show your current IP address."
+    },
+    {
       "name": "arch",
       "url": "https://github.com/windwhinny/spaceship-arch",
       "description": "The arch section for Spaceship prompt shows if current shell running in x86 env."


### PR DESCRIPTION
#### Description

Added https://github.com/TheArqsz/spaceship-ip to a [docs/registry/external.json](https://github.com/spaceship-prompt/spaceship-prompt/blob/master/docs/registry/external.json).

I haven't seen any section that does that and I find it personally quite useful.

#### Screenshot

![image](https://github.com/spaceship-prompt/spaceship-prompt/assets/38382850/33cf8313-54e8-424e-8c92-ec8ad3218b0d)
