### PR TITLE
fix: kubectl version output redirect

### DIFF
--- a/sections/kubectl_version.zsh
+++ b/sections/kubectl_version.zsh
@@ -31,7 +31,7 @@ spaceship_kubectl_version() {
   [[ -z $kube_context ]] && return
 
   # if kubectl can't connect kubernetes cluster, kubernetes version section will be not shown
-  local kubectl_version=$(kubectl version>/dev/null | grep "Server Version" | sed 's/Server Version: \(.*\)/\1/')
+  local kubectl_version=$(kubectl version 2>/dev/null | grep "Server Version" | sed 's/Server Version: \(.*\)/\1/')
   [[ -z $kubectl_version ]] && return
 
   spaceship::section \


### PR DESCRIPTION
#### Description

I believe that the current implementation redirects all the output to `dev/null`. This PR fixes it by only redirecting the errors.