### PR TITLE
Add a new option to git_branch to show the remote name

### DIFF
--- a/sections/git_branch.zsh
+++ b/sections/git_branch.zsh
@@ -8,6 +8,7 @@
 # ------------------------------------------------------------------------------
 
 SPACESHIP_GIT_BRANCH_SHOW="${SPACESHIP_GIT_BRANCH_SHOW=true}"
+SPACESHIP_GIT_BRANCH_REMOTE_SHOW="${SPACESHIP_GIT_BRANCH_REMOTE_SHOW=true}"
 SPACESHIP_GIT_BRANCH_ASYNC="${SPACESHIP_GIT_BRANCH_ASYNC=false}"
 SPACESHIP_GIT_BRANCH_PREFIX="${SPACESHIP_GIT_BRANCH_PREFIX="$SPACESHIP_GIT_SYMBOL"}"
 SPACESHIP_GIT_BRANCH_SUFFIX="${SPACESHIP_GIT_BRANCH_SUFFIX=""}"
@@ -22,11 +23,18 @@ spaceship_git_branch() {
 
   vcs_info
 
-  local git_current_branch="$vcs_info_msg_0_"
+  local INDEX INDEX_PARTS git_current_branch="$vcs_info_msg_0_"
   [[ -z "$git_current_branch" ]] && return
 
   git_current_branch="${git_current_branch#heads/}"
   git_current_branch="${git_current_branch/.../}"
+  # If we want to show the remote with the branch name, check if the branch
+  # is tracking a remote and use that info if there.
+  if [[ $SPACESHIP_GIT_BRANCH_REMOTE_SHOW == true ]]; then
+    INDEX=$(command git status --porcelain -b 2> /dev/null)
+    INDEX_PARTS=(${(@s:...:)INDEX})
+    [[ ${#INDEX_PARTS[@]} -eq 2 ]] && git_current_branch="${INDEX_PARTS[2]}"
+  fi
 
   spaceship::section \
     --color "$SPACESHIP_GIT_BRANCH_COLOR" \


### PR DESCRIPTION
Add option SPACESHIP_GIT_BRANCH_REMOTE_SHOW that will show the
remote/branch if the branch is tracking a remote branch.
