### PR TITLE
Adds Mise-en-Place Support for Ruby Version in Prompt

### DIFF
--- a/docs/sections/ruby.md
+++ b/docs/sections/ruby.md
@@ -5,7 +5,7 @@
 !!! info
     [**Ruby**](https://www.ruby-lang.org) is a dynamic, reflective, object-oriented, general-purpose programming language.
 
-The `ruby` section displays the version of Ruby. This section supports [rvm-prompt](https://rvm.io/workflow/prompt), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv) and [asdf](https://asdf-vm.com) version managers.
+The `ruby` section displays the version of Ruby. This section supports [rvm-prompt](https://rvm.io/workflow/prompt), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv), [mise-en-place](https://mise.jdx.dev/), and [asdf](https://asdf-vm.com) version managers.
 
 This section is displayed only when the current directory is within a Ruby project, meaning:
 

--- a/docs/uk/sections/ruby.md
+++ b/docs/uk/sections/ruby.md
@@ -5,7 +5,7 @@
 !!! info "Інформація"
     [**Ruby**](https://www.ruby-lang.org) — це динамічна, рефлексивна, об’єктноорієнтована мова програмування загального призначення.
 
-Секція `ruby` відображає версію Ruby. Секція підтримує менеджери керування версіями [rvm-prompt](https://rvm.io/workflow/prompt), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv) та [asdf](https://asdf-vm.com).
+Секція `ruby` відображає версію Ruby. Секція підтримує менеджери керування версіями [rvm-prompt](https://rvm.io/workflow/prompt), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv), [mise-en-place](https://mise.jdx.dev/) та [asdf](https://asdf-vm.com).
 
 Ця секція відображається лише тоді, коли поточний каталог знаходиться у Ruby-проєкті, тобто:
 

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -30,11 +30,13 @@ spaceship_ruby() {
   local ruby_version
 
   if spaceship::exists rvm-prompt; then
-    ruby_version=$(rvm-prompt i v g)
+    ruby_version=$(rvm-prompt i v g 2>/dev/null)
   elif spaceship::exists chruby; then
-    ruby_version=$(chruby | sed -n -e 's/ \* //p')
+    ruby_version=$(chruby 2>/dev/null | sed -n -e 's/ \* //p')
   elif spaceship::exists rbenv; then
-    ruby_version=$(rbenv version-name)
+    ruby_version=$(rbenv version-name 2>/dev/null)
+  elif spaceship::exists mise; then
+    ruby_version=$(mise current ruby 2>/dev/null)
   elif spaceship::exists asdf; then
     local asdf_output
     if asdf_output=$(asdf current --no-header ruby 2>/dev/null) && [[ -n "$asdf_output" ]]; then


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

[mise-en-place](https://mise.jdx.dev/) is a Rust version-control tool, influenced by or based on asdf. This PR proposes to add support for retrieving the current Ruby runtime version from `mise`.

#### Screenshot

<img width="368" alt="image" src="https://github.com/user-attachments/assets/7b7349c3-52ff-4739-979c-65dbc634364c">