### PR TITLE
fix: docker section is shown always in rootless mode

### DIFF
--- a/sections/docker_context.zsh
+++ b/sections/docker_context.zsh
@@ -34,7 +34,7 @@ spaceship_docker_context() {
     # Docker contexts can be set using either the DOCKER_CONTEXT environment variable
     # or the `docker context use` command. `docker context ls` will show the selected
     # context in both cases. But we are not interested in the local "default" context.
-    docker_remote_context=$(docker context ls --format '{{if .Current}}{{if and (ne .Name "default") (ne .Name "desktop-linux") (ne .Name "colima")}}{{.Name}}{{end}}{{end}}' 2>/dev/null)
+    docker_remote_context=$(docker context ls --format '{{if .Current}}{{if and (ne .Name "default") (ne .Name "rootless") (ne .Name "desktop-linux") (ne .Name "colima")}}{{.Name}}{{end}}{{end}}' 2>/dev/null)
     [[ $? -ne 0 ]] && return
 
     docker_remote_context=$(echo $docker_remote_context | tr -d '\n')


### PR DESCRIPTION
#### Description

docker has [rootless mode](https://docs.docker.com/engine/security/rootless/), where 'docker context ls' command returns besides 'default' entry also 'rootless' entry:
```shell
docker context ls
```
|NAME        |DESCRIPTION                                                      |DOCKER ENDPOINT                     |ERROR|
|---------------|----------------------------------------------------------------|----------------------------------------------|----------|
|default      |Current DOCKER_HOST based configuration|unix:///var/run/docker.sock        ||
|rootless * |Rootless mode                                                     |unix:///run/user/1000/docker.sock ||

this leads to docker prompt section is shown always,  

![grafik](https://github.com/user-attachments/assets/fb70b095-d575-4bfe-8509-00ec0b57436e)

to prevent this behavior it need to be filtered out like the 'default' entry

a similar fix was already applied in https://github.com/spaceship-prompt/spaceship-prompt/issues/1025 for macOS specific docker context
