### PR TITLE
Add a section for uv.lock based Python environments

### DIFF
--- a/docs/config/prompt.md
+++ b/docs/config/prompt.md
@@ -73,6 +73,7 @@ SPACESHIP_PROMPT_ORDER=(
   azure          # Azure section
   venv           # virtualenv section
   conda          # conda virtualenv section
+  uv             # uv section
   dotnet         # .NET section
   ocaml          # OCaml section
   vlang          # V section

--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -332,6 +332,12 @@
       "internal": true
     },
     {
+      "name": "uv",
+      "url": "https://spaceship-prompt.sh/sections/uv",
+      "description": "The uv package manager.",
+      "internal": true
+    },
+    {
       "name": "venv",
       "url": "https://spaceship-prompt.sh/sections/venv",
       "description": "The current Virtualenv name.",

--- a/docs/sections/uv.md
+++ b/docs/sections/uv.md
@@ -1,0 +1,24 @@
+# uv (uv)
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**uv**](https://docs.astral.sh/uv/) is an extremely fast Python package and project manager, written in Rust.
+
+The `uv` section displays the version of the Python inside the `.venv` environment created by `uv` at the root of the project.
+
+This section is displayed only when the current directory is within a uv project, meaning:
+
+* Upsearch finds a `uv.lock` file
+* Current directory contains a `.venv` directory with a valid Python interpreter
+
+## Options
+
+| Variable              |              Default               | Meaning                             |
+| :-------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_UV_SHOW`   |               `true`               | Show section                        |
+| `SPACESHIP_UV_ASYNC`  |               `true`               | Render section asynchronously       |
+| `SPACESHIP_UV_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
+| `SPACESHIP_UV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_UV_SYMBOL` |               `uv·`                | Symbol displayed before the section |
+| `SPACESHIP_UV_COLOR`  |              `yellow`              | Section's color                     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
         - Terraform (terraform): sections/terraform.md
         - Time (time): sections/time.md
         - Username (user): sections/user.md
+        - uv (uv): sections/uv.md
         - v (vlang): sections/vlang.md
         - Virtualenv (venv): sections/venv.md
         - Xcode (xcode): sections/xcode.md
@@ -226,6 +227,6 @@ plugins:
         - locale: zh
           name: 简体中文
           build: true
-        - locale: "null" 
+        - locale: "null"
           name: Help translating
           fixed_link: https://translate.spaceship-prompt.sh/

--- a/sections/uv.zsh
+++ b/sections/uv.zsh
@@ -1,0 +1,46 @@
+#
+# uv
+# uv is a Python package and project manager
+# Link: docs.astral.sh/uv
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_UV_SHOW="${SPACESHIP_UV_SHOW=true}"
+SPACESHIP_UV_ASYNC="${SPACESHIP_UV_ASYNC=true}"
+SPACESHIP_UV_PREFIX="${SPACESHIP_UV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_UV_SUFFIX="${SPACESHIP_UV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_UV_SYMBOL="${SPACESHIP_UV_SYMBOL="uv "}"
+SPACESHIP_UV_COLOR="${SPACESHIP_UV_COLOR="yellow"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# Show current version of Python
+spaceship_uv() {
+  [[ $SPACESHIP_UV_SHOW == false ]] && return
+
+  [[ -n $VIRTUAL_ENV ]] && return
+
+  # Show python version only in directories with relevant files
+  local is_python_project="$(spaceship::upsearch uv.lock)"
+
+  [[ -n "$is_python_project" ]] || return
+
+  local venv=$is_python_project:h/.venv
+
+  if [[ -d $venv ]]; then
+    py_version=${(@)$($venv/bin/python -V 2>&1)[2]}
+  fi
+
+  [[ -z $py_version ]] && return
+
+  spaceship::section \
+    --color "$SPACESHIP_UV_COLOR" \
+    --prefix "$SPACESHIP_UV_PREFIX" \
+    --suffix "$SPACESHIP_UV_SUFFIX" \
+    --symbol "$SPACESHIP_UV_SYMBOL" \
+    "$py_version"
+}

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -76,6 +76,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     azure          # Azure section
     venv           # virtualenv section
     conda          # conda virtualenv section
+    uv             # uv virtualenv section
     dotnet         # .NET section
     ocaml          # OCaml section
     vlang          # V section


### PR DESCRIPTION
#### Description

This pull requests adds support for the [uv](https://docs.astral.sh/uv/) package manager for Python. uv works with virtual environments but does not activate them, since all commands are supposed to be run with the `uv` prefix: `uv run python`, `uv run pytest`, `uv pip`, etc.

This module checks for a `uv.lock` file, and for a virtual environment in the `.venv` folder below. If available, it adds an entry such as `via uv 3.13.0`.

If a virtual environment is activated, then the uv entry is silenced.

#### Screenshot

<img width="686" alt="uv screenshot" src="https://github.com/user-attachments/assets/5886c651-9101-4d2e-8126-01014890541c">


