### PR TITLE
add no-header tag to asdf prompt

### DIFF
--- a/sections/elixir.zsh
+++ b/sections/elixir.zsh
@@ -34,7 +34,7 @@ spaceship_elixir() {
   elif spaceship::exists exenv; then
     elixir_version=$(exenv version-name)
   elif spaceship::exists asdf; then
-    elixir_version=${$(asdf current elixir)[2]}
+    elixir_version=${$(asdf current --no-header elixir)[2]}
   fi
 
   if [[ $elixir_version == "" ]]; then

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -37,7 +37,7 @@ spaceship_ruby() {
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
     # split output on space and return second element
-    ruby_version=${$(asdf current ruby)[2]}
+    ruby_version=${$(asdf current --no-header ruby)[2]}
   else
     return
   fi


### PR DESCRIPTION
#### Description
When using ASDF version manager with elixir, the prompt shows the word "Version" instead of the actual elixir version. This is because asdf shows a header line, which can be removed with a --no-header flag. In this PR I have added to the flag to command, which has solved the problem. 

#### Screenshot

<img width="686" alt="Screenshot 2025-02-09 at 16 07 49" src="https://github.com/user-attachments/assets/c78ce01d-14f6-4287-bf00-de5001c003b9" />

