### PR TITLE
Fix grammar in `xcenv` and `xcode` section docs

### DIFF
--- a/docs/sections/xcenv.md
+++ b/docs/sections/xcenv.md
@@ -5,7 +5,7 @@
 !!! info
     Use [**xcenv**](https://xcenv.org/) to document and manage the Xcode version for your project and system..
 
-The `xcenv` section displays the version of the Xcode.
+The `xcenv` section displays the version of Xcode.
 
 The local version has more priority than the global one.
 

--- a/docs/sections/xcode.md
+++ b/docs/sections/xcode.md
@@ -5,7 +5,7 @@
 !!! info
     [**Xcode**](https://developer.apple.com/xcode/) is a suite of tools developers use to build apps for Apple platforms.
 
-The `xcode` section displays the version of the Xcode.
+The `xcode` section displays the version of Xcode.
 
 ## Options
 


### PR DESCRIPTION
#### Description

Fixes grammar in `xcenv` and `xcode` section docs by removing extraneous "the".