### PR TITLE
Fix `xcode` section to only run `xed` if command exists

### DIFF
--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -47,4 +47,7 @@ spaceship_xcode() {
     "v$xcode_version"
 }
 
-(xed --version >/dev/null 2>&1 &) # Perform once in background since first execution is slow.
+if command -v xed >/dev/null 2>&1
+then
+  xed --version >/dev/null 2>&1 & # Perform once in background since first execution is slow.
+fi

--- a/sections/xcode.zsh
+++ b/sections/xcode.zsh
@@ -49,5 +49,5 @@ spaceship_xcode() {
 
 if command -v xed >/dev/null 2>&1
 then
-  xed --version >/dev/null 2>&1 & # Perform once in background since first execution is slow.
+  (xed --version >/dev/null 2>&1 &) # Perform once in background since first execution is slow.
 fi


### PR DESCRIPTION
#### Description

Fixes the `xcode` section to only run `xed` if command exists.