### PR TITLE
fix(sections/jobs): add support for ZSH <5.9

### DIFF
--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -25,6 +25,14 @@ spaceship_jobs() {
 
   local jobs_amount=${#jobstates}
 
+  # Workaround for Zsh < 5.9 (#1449)
+  if ! is-at-least 5.9; then
+    jobs_amount=0;
+    while IFS= read -r line; do
+      [[ -n ${line//[[:space:]]/} ]] && ((jobs_amount++))
+    done <<< "$(jobs)"
+  fi
+
   [[ $jobs_amount -gt 0 ]] || return
 
   if [[ $jobs_amount -le $SPACESHIP_JOBS_AMOUNT_THRESHOLD ]]; then


### PR DESCRIPTION
#### Description

On ZSH <5.9, $jobstates is not propagated properly to subshells. This means that the jobs module doesn't work properly on those shell versions. 5.8 is default on some LTS and distros with old versions.

This fixes https://github.com/spaceship-prompt/spaceship-prompt/issues/1449

#### Screenshot

Before:
```console
Sayrus ~
➜ nvim &

Sayrus ~
➜ jobs    
[1]  + suspended  nvim

# Only relevant for context
Sayrus ~
➜ echo $jobstates    
suspended:+:1225175=suspended

Sayrus ~
➜ $(echo $jobstates)

```

After:
```console
Sayrus ~
➜ nvim &

✦ Sayrus ~
➜ jobs    
[1]  + suspended  nvim
```
Note the `✦` character from the jobs section.
