### PR TITLE
more robust ruby/elixir version detection when asdf is installed

### DIFF
--- a/sections/elixir.zsh
+++ b/sections/elixir.zsh
@@ -34,7 +34,10 @@ spaceship_elixir() {
   elif spaceship::exists exenv; then
     elixir_version=$(exenv version-name)
   elif spaceship::exists asdf; then
-    elixir_version=${$(asdf current --no-header elixir)[2]}
+    local asdf_output
+    if asdf_output=$(asdf current --no-header elixir 2>/dev/null) && [[ -n "$asdf_output" ]]; then
+      elixir_version=${asdf_output[(w)2]}
+    fi
   fi
 
   if [[ $elixir_version == "" ]]; then

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -36,8 +36,11 @@ spaceship_ruby() {
   elif spaceship::exists rbenv; then
     ruby_version=$(rbenv version-name)
   elif spaceship::exists asdf; then
-    # split output on space and return second element
-    ruby_version=${$(asdf current --no-header ruby)[2]}
+    local asdf_output
+    if asdf_output=$(asdf current --no-header ruby 2>/dev/null) && [[ -n "$asdf_output" ]]; then
+      # split output on space and return second element
+      ruby_version=${asdf_output[(w)2]}
+    fi
   else
     return
   fi


### PR DESCRIPTION
#### Description

Resolves issue #1508 

Handle the use case when asdf is installed, but is **not** managing ruby/elixir.

#### Screenshot

<img width="1211" height="417" alt="image" src="https://github.com/user-attachments/assets/6274a935-2b31-4148-b38c-d65304b794ad" />