### PR TITLE
fix(sections/ansible): exclude ansible cfg files in home folder due to false positive

### DIFF
--- a/sections/ansible.zsh
+++ b/sections/ansible.zsh
@@ -38,6 +38,10 @@ spaceship_ansible() {
     detected_playbooks="$(spaceship::grep -oE "tasks|hosts|roles" $yaml_files)"
   fi
 
+  if [[ -n "$ansible_configs" ]] && [[ "$ansible_configs" == "$HOME/.ansible.cfg" || "$ansible_configs" == "$HOME/ansible.cfg" ]]; then
+    unset ansible_configs
+  fi
+
   [[ -n "$ansible_configs" || -n "$detected_playbooks" ]] || return
 
   # Retrieve ansible version


### PR DESCRIPTION
#### Description

This pull request addresses a false positive in the detection of Ansible projects. 

It is common to have `.ansible.cfg` or `ansible.cfg` files in the home directory to globally customize Ansible's behavior. However, the presence of such configuration files in the home folder does **not** mean that the home directory itself (or any of its generic subfolders, such as `~/Downloads`) should be considered an Ansible project.

Currently, the `upsearch` function searches for these files recursively from the current directory up to the root directory. As a result, when an `.ansible.cfg` or `ansible.cfg` file is found in the user's home folder, the Ansible section in the prompt is displayed in every directory under the home—even in unrelated folders such as `Downloads`, `Documents`, etc. This leads to showing the Ansible version in almost any folder inside the user's home, which can be confusing and is not the intended behavior.

With this change, Ansible configuration files located **specifically in the home directory** will no longer trigger the display of the Ansible prompt section, making the project detection more accurate and reducing unnecessary noise in unrelated folders.