### PR TITLE
docs: update unavatar docs urls

### DIFF
--- a/docs/blog/2017-spaceship-v2.md
+++ b/docs/blog/2017-spaceship-v2.md
@@ -1,7 +1,7 @@
 # A big update of spaceship-zsh-theme
 
 <aside class="mdx-author" markdown>
-  ![@denysdovhna](https://unavatar.io/denysdovhan)
+  ![@denysdovhna](https://unavatar.io/github/denysdovhan)
 
   <span>__Denys Dovhan__ · @denysdovhan</span>
   <span>

--- a/docs/blog/2018-spaceship-v3.md
+++ b/docs/blog/2018-spaceship-v3.md
@@ -1,7 +1,7 @@
 # Meet Spaceship ZSH v3.0!
 
 <aside class="mdx-author" markdown>
-  ![@denysdovhan](https://unavatar.io/denysdovhan)
+  ![@denysdovhan](https://unavatar.io/github/denysdovhan)
 
   <span>__Denys Dovhan__ · @denysdovhan</span>
   <span>

--- a/docs/blog/2022-spaceship-v4.md
+++ b/docs/blog/2022-spaceship-v4.md
@@ -1,7 +1,7 @@
 # Announcing Spaceship v4 — the faster, the better
 
 <aside class="mdx-author" markdown>
-  ![@denysdovhan](https://unavatar.io/denysdovhan)
+  ![@denysdovhan](https://unavatar.io/github/denysdovhan)
 
   <span>__Denys Dovhan__ · @denysdovhan</span>
   <span>

--- a/docs/blog/2026-extract-path-injection.md
+++ b/docs/blog/2026-extract-path-injection.md
@@ -1,7 +1,7 @@
 # Fixing path-based interpreter injection in Spaceship
 
 <aside class="mdx-author" markdown>
-  ![@denysdovhan](https://unavatar.io/denysdovhan)
+  ![@denysdovhan](https://unavatar.io/github/denysdovhan)
 
 <span>**Denys Dovhan** · @denysdovhan</span>
 <span>

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -94,4 +94,4 @@ I’ve been working on big PR for spaceship-zsh-theme last few weeks. This is th
 
 <!-- Common References -->
 
-[denysdovhan]: https://unavatar.io/denysdovhan
+[denysdovhan]: https://unavatar.io/github/denysdovhan


### PR DESCRIPTION
This change fixes broken author avatar images in the blog docs.

The docs were still using the old `https://unavatar.io/<username>` URL shape. Unavatar changed the API, and those links no longer reliably resolve to valid images. As a result, blog post author avatars could fail to render in documentation pages, which degrades the presentation of the docs and leaves broken image content in the blog index and post headers.

The root cause was that the repository had several hard-coded legacy Unavatar URLs for the `denysdovhan` profile. Those URLs were never updated when the provider changed its routing format.

The fix updates every docs reference from `https://unavatar.io/denysdovhan` to `https://unavatar.io/github/denysdovhan`, which is the current valid GitHub-specific form. The change is limited to the affected markdown files and does not alter any rendering logic or site code.

Validation was done by running the repository test suite with `./scripts/tests`, which passed successfully after the docs updates.
