### PR TITLE
feat: add helm section

### DIFF
--- a/docs/config/prompt.md
+++ b/docs/config/prompt.md
@@ -68,6 +68,7 @@ SPACESHIP_PROMPT_ORDER=(
   dart           # Dart section
   julia          # Julia section
   crystal        # Crystal section
+  helm           # Helm section
   docker         # Docker section
   docker_compose # Docker section
   aws            # Amazon Web Services section

--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -152,6 +152,12 @@
       "internal": true
     },
     {
+      "name": "helm",
+      "url": "https://helm.sh/",
+      "description": "The version of Helm",
+      "internal": true
+    },
+    {
       "name": "hg",
       "url": "https://spaceship-prompt.sh/sections/hg",
       "description": "The information about the current Mercurial repository.",

--- a/docs/sections/helm.md
+++ b/docs/sections/helm.md
@@ -1,0 +1,23 @@
+# Helm `helm`
+
+!!! important "This section is rendered asynchronously by default"
+
+!!! info
+    [**Helm**](https://helm.sh) Helm helps you manage Kubernetes applications — Helm Charts help you define, install, and upgrade even the most complex Kubernetes application.
+
+The `helm` section displays the version of the Helm.
+
+This section is displayed only when the current directory is within a Helm project, meaning:
+
+* Upsearch finds helmfile.yaml or Chart.yaml 
+
+## Options
+
+| Variable                |              Default               | Meaning                             |
+| :---------------------- | :--------------------------------: | ----------------------------------- |
+| `SPACESHIP_HELM_SHOW`   |               `true`               | Show section                        |
+| `SPACESHIP_HELM_ASYNC`  |               `true`               | Render section asynchronously       |
+| `SPACESHIP_HELM_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Section's prefix                    |
+| `SPACESHIP_HELM_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Section's suffix                    |
+| `SPACESHIP_HELM_SYMBOL` |               `⎈ `                 | Symbol displayed before the section |
+| `SPACESHIP_HELM_COLOR`  |               `blue`               | Section's color                     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
         - Go (golang): sections/golang.md
         - Google Cloud (gcloud): sections/gcloud.md
         - Haskell (haskell): sections/haskell.md
+        - Helm (helm): sections/helm.md
         - Hostname (host): sections/host.md
         - IBM Cloud (ibmcloud): sections/ibmcloud.md
         - Java (java): sections/java.md

--- a/sections/helm.zsh
+++ b/sections/helm.zsh
@@ -1,0 +1,39 @@
+#
+# Helm
+#
+# Helm is a tool for managing Kubernetes packages called charts.
+# Link: https://helm.sh/
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_HELM_SHOW="${SPACESHIP_HELM_SHOW=true}"
+SPACESHIP_HELM_ASYNC="${SPACESHIP_HELM_ASYNC=true}"
+SPACESHIP_HELM_PREFIX="${SPACESHIP_HELM_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_HELM_SUFFIX="${SPACESHIP_HELM_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_HELM_SYMBOL="${SPACESHIP_HELM_SYMBOL="⎈ "}"
+SPACESHIP_HELM_COLOR="${SPACESHIP_HELM_COLOR="blue"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_helm() {
+  [[ $SPACESHIP_HELM_SHOW == false ]] && return
+  
+  spaceship::exists helm || return
+
+  local is_helm_project="$(spaceship::upsearch helmfile.yaml Chart.yaml)"
+
+  [[ -n "$is_helm_project" ]] || return
+  
+  local helm_version=$(helm version --short --client 2>/dev/null | awk '{print $1}')
+
+  spaceship::section \
+    --color "$SPACESHIP_HELM_COLOR" \
+    --prefix "$SPACESHIP_HELM_PREFIX" \
+    --suffix "$SPACESHIP_HELM_SUFFIX" \
+    --symbol "$SPACESHIP_HELM_SYMBOL" \
+    "$helm_version"
+}

--- a/sections/helm.zsh
+++ b/sections/helm.zsh
@@ -30,6 +30,8 @@ spaceship_helm() {
   
   local helm_version=$(helm version --short --client 2>/dev/null | awk '{print $1}')
 
+  [[ -n "$helm_version" ]] || return
+
   spaceship::section \
     --color "$SPACESHIP_HELM_COLOR" \
     --prefix "$SPACESHIP_HELM_PREFIX" \

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -73,6 +73,7 @@ if [ -z "$SPACESHIP_PROMPT_ORDER" ]; then
     dart           # Dart section
     julia          # Julia section
     crystal        # Crystal section
+    helm           # Helm section
     docker         # Docker section
     docker_compose # Docker section
     aws            # Amazon Web Services section

--- a/tests/helm.test.zsh
+++ b/tests/helm.test.zsh
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  HELM_VERSION="v3.20.1"
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(helm)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_HELM_SHOW="true"
+  SPACESHIP_HELM_PREFIX="via "
+  SPACESHIP_HELM_SUFFIX=""
+  SPACESHIP_HELM_SYMBOL="🔮 "
+  SPACESHIP_HELM_COLOR="blue"
+
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_HELM_SHOW
+  unset SPACESHIP_HELM_PREFIX
+  unset SPACESHIP_HELM_SUFFIX
+  unset SPACESHIP_HELM_SYMBOL
+  unset SPACESHIP_HELM_COLOR
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_helm_no_files() {
+  local no_files_expected=""
+  local no_files_actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render without files" "$no_files_expected" "$no_files_actual"
+}
+
+
+test_helm_upsearch_file() {
+	FILES=(helmfile.yaml Chart.yaml)
+	for file in $FILES; do
+		touch $file
+		local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_HELM_COLOR}%}${SPACESHIP_HELM_SYMBOL}${HELM_VERSION}%{%b%f%}"
+		local actual="$(spaceship::testkit::render_prompt)"
+		assertEquals "should render with extension for file $file" "$expected" "$actual"
+		rm $file
+	done
+}
+
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source tests/shunit2/shunit2

--- a/tests/stubs/helm
+++ b/tests/stubs/helm
@@ -1,0 +1,3 @@
+#!/usr/bin/env zsh
+
+echo "v3.20.1"


### PR DESCRIPTION
Closes #1216. Adds a new section to display the Helm version when `helmfile.yaml` or `Chart.yaml` are present.