### PR TITLE
added check for cargo virtual workspace to not error on no package

### DIFF
--- a/sections/package.zsh
+++ b/sections/package.zsh
@@ -71,7 +71,11 @@ spaceship_package::lerna() {
 
 spaceship_package::cargo() {
   spaceship::exists cargo || return
-  spaceship::upsearch -s Cargo.toml || return
+  spaceship::upsearch -s Cargo.toml || return 
+
+  # Skip virtual workspaces (no [package] section)
+  local cargo_toml=$(spaceship::upsearch Cargo.toml)
+  grep -q '^\[package\]' "$cargo_toml" || return
 
   # Handle missing field `version` in Cargo.toml.
   # `cargo pkgid` need Cargo.lock exists too. If it does't, do not show package version


### PR DESCRIPTION
#### Description
If you are standing in a cargo workspace with no packages defined in the top level, then the prompt currently throws an error as it detects a `Cargo.toml`, but it contains no `[package]` section and thus the `cargo pkigid` command fails. 
<img width="1487" height="104" alt="image" src="https://github.com/user-attachments/assets/931526e7-56e1-4560-9c7e-6120a84411af" />

My repository setup is:
root -> crates -> crateA
                         -> crateB

And when standing in root it just sees the root `Cargo.toml` and throws this error. 

Testing on my own machine this addition of checking if the `Cargo.toml` includes a `[package]` tag before trying to run the `pkgid` command seems to work to avoid the situration. I tried to see if I could roll the `cargo.toml` check and save it on the same line with a single upsearch, but when I tried it threw errors on me, and I kept it as it is now. (I expect someone more knowledgeable with zsh will be able to point out how to optimize it if needed)

However , I have noticed that my spaceship prompt seems to be inconsistent on what it shows, and not quite sure if its something in this change that does it, or something else. 
As you see in the screenshot below, standing in the same repo and running `ls` multiple times gives different prompts.

It seems to be inconsistent between when it shows git branch, docker version, rust version. I tried to google about it and check for existing issues, but nothing came up. 
<img width="806" height="883" alt="image" src="https://github.com/user-attachments/assets/3c76c742-6992-4a5a-bc8f-bb4329907c82" />
