### PR TITLE
Fix(dotnet): added .slnx solution file detection

### DIFF
--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -26,7 +26,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   local is_dotnet_project="$(spaceship::upsearch project.json global.json paket.dependencies)"
-  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(#qN^/) ]] || return
+  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(#qN^/) || -n *.slnx(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -26,7 +26,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   local is_dotnet_project="$(spaceship::upsearch project.json global.json paket.dependencies)"
-  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(x|)(#qN^/) || return
+  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(x|)(#qN^/) ]] || return
 
   spaceship::exists dotnet || return
 

--- a/sections/dotnet.zsh
+++ b/sections/dotnet.zsh
@@ -26,7 +26,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   local is_dotnet_project="$(spaceship::upsearch project.json global.json paket.dependencies)"
-  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(#qN^/) || -n *.slnx(#qN^/) ]] || return
+  [[ -n "$is_dotnet_project" || -n *.(cs|fs|x)proj(#qN^/) || -n *.sln(x|)(#qN^/) || return
 
   spaceship::exists dotnet || return
 


### PR DESCRIPTION
## Problem
The .slnx format is the new XML-based solution file format introduced in
.NET 9 and the new default in .NET 10. Spaceship's dotnet section only detects .sln files, so it doesn't activate in projects using the new format.

## Solution
Add *.slnx to the file detection glob on line 29 of sections/dotnet.zsh.
