### PR TITLE
fix(dart): fix dart section

### DIFF
--- a/sections/dart.zsh
+++ b/sections/dart.zsh
@@ -29,7 +29,7 @@ spaceship_dart() {
   # The version can have the following patterns:
   # dart-sdk >       Dart SDK version: 2.19.0-edge.efb509c114dcaf54d0a011f717b48893d71ec9c3 (be) (Thu Sep 29 01:58:56 2022 +0000) on "macos_x64"
   # flutter bundle > Dart SDK version: 2.18.1 (stable) (Tue Sep 13 11:42:55 2022 +0200) on "macos_x64"
-  local dart_version=$(dart --version | awk '{sub(/-.*/, "", $4); print $4}')
+  local dart_version=$(dart --version | awk '{ if ($1 ~ /^Dart/) {sub(/-.*/, "", $4); print $4} }')
 
   spaceship::section \
     --color "$SPACESHIP_DART_COLOR" \

--- a/tests/dart.test.zsh
+++ b/tests/dart.test.zsh
@@ -113,6 +113,31 @@ test_dart_sdk() {
   rm $file
 }
 
+test_dart_fvm() {
+  # alias to mock dart command installed as fvm
+  _dart() {
+    case "$1" in
+      --version)
+        printf "  Total    Received Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  205M  100  205M    0     0  8415k      0  0:00:25  0:00:25 --:--:--  9.8M
+Dart SDK version: 3.12.2 (stable) (Tue Jun 9 01:11:39 2026 -0700) on \"macos_arm64\""
+        ;;
+      *)
+        command dart "$@"
+        ;;
+    esac
+  }
+  alias "dart"="_dart"
+  local DART_VERSION="3.12.2"
+  file="main.dart"
+  touch $file
+  local expected="%{%B%}via %{%b%}%{%B%F{$SPACESHIP_DART_COLOR}%}${SPACESHIP_DART_SYMBOL}v$DART_VERSION%{%b%f%}"
+  local actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should render with $file" "$expected" "$actual"
+  rm $file
+}
+
 # ------------------------------------------------------------------------------
 # SHUNIT2
 # Run tests with shunit2


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

This PR fixes a display issue that occurs the first time `fvm` initializes. 

When a user runs a project utilizing FVM for the first time, FVM triggers background network checks or SDK status resolutions. Under certain terminal configurations, this background process leaks network/download progress metadata (`Received Spent 0`) into the prompt, messing up the terminal rendering.