### PR TITLE
feat(git): add git state section for detecting active operations

### DIFF
--- a/docs/registry/internal.json
+++ b/docs/registry/internal.json
@@ -128,6 +128,12 @@
       "internal": true
     },
     {
+      "name": "git_state",
+      "url": "https://spaceship-prompt.sh/sections/git/#git-state-git_state",
+      "description": "The active Git operation state (rebase, merge, revert, cherry-pick, bisect).",
+      "internal": true
+    },
+    {
       "name": "git_commit",
       "url": "https://spaceship-prompt.sh/sections/git/#git-commit-git_commit",
       "description": "The current Git commit hash.",

--- a/docs/sections/git.md
+++ b/docs/sections/git.md
@@ -2,7 +2,7 @@
 
 !!! important "This section is rendered asynchronously by default"
 
-The `git` section consists of [`git_branch`](#git-branch-git_branch) and [`git_status`](#git-status-git_status) and [`git_commit`](#git-commit-git_commit) subsections.
+The `git` section consists of [`git_branch`](#git-branch-git_branch), [`git_status`](#git-status-git_status), [`git_state`](#git-state-git_state) and [`git_commit`](#git-commit-git_commit) subsections.
 
 ## Options
 
@@ -52,6 +52,26 @@ The `git_status` subsection displays indicators only when you have a dirty Git r
 | `SPACESHIP_GIT_STATUS_AHEAD`     |   `⇡`   | Indicator for unpushed changes (ahead of remote branch)      |
 | `SPACESHIP_GIT_STATUS_BEHIND`    |   `⇣`   | Indicator for unpulled changes (behind of remote branch)     |
 | `SPACESHIP_GIT_STATUS_DIVERGED`  |   `⇕`   | Indicator for diverged changes (diverged with remote branch) |
+
+## Git state `git_state`
+
+The `git_state` subsection displays the active git operation state (if any), such as rebase, merge, revert, cherry-pick, or bisect.
+
+### Options
+
+| Variable                            | Default | Meaning                                |
+| :---------------------------------- | :-----: | -------------------------------------- |
+| `SPACESHIP_GIT_STATE_SHOW`          | `true`  | Show section                           |
+| `SPACESHIP_GIT_STATE_ASYNC`         | `false` | Render section asynchronously          |
+| `SPACESHIP_GIT_STATE_PREFIX`        |  ` [`   | Prefix before git state subsection     |
+| `SPACESHIP_GIT_STATE_SUFFIX`        |   `]`   | Suffix after git state subsection      |
+| `SPACESHIP_GIT_STATE_COLOR`         |  `red`  | Color of git state subsection          |
+| `SPACESHIP_GIT_STATE_REBASE_REBASING` | `rebase` | Text shown during rebase             |
+| `SPACESHIP_GIT_STATE_REBASE_APPLYING` |  `am`  | Text shown during git am              |
+| `SPACESHIP_GIT_STATE_MERGING`       | `merge` | Text shown during merge               |
+| `SPACESHIP_GIT_STATE_REVERTING`     | `revert` | Text shown during revert             |
+| `SPACESHIP_GIT_STATE_CHERRY_PICKING` | `cherry-pick` | Text shown during cherry-pick    |
+| `SPACESHIP_GIT_STATE_BISECTING`     | `bisect` | Text shown during bisect             |
 
 ## Git commit `git_commit`
 

--- a/sections/git.zsh
+++ b/sections/git.zsh
@@ -13,7 +13,7 @@ SPACESHIP_GIT_SUFFIX="${SPACESHIP_GIT_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}
 SPACESHIP_GIT_SYMBOL="${SPACESHIP_GIT_SYMBOL=" "}"
 
 if [ -z "$SPACESHIP_GIT_ORDER" ]; then
-  SPACESHIP_GIT_ORDER=(git_branch git_status git_commit)
+  SPACESHIP_GIT_ORDER=(git_branch git_status git_state git_commit)
 fi
 
 # ------------------------------------------------------------------------------
@@ -22,19 +22,22 @@ fi
 
 source "$SPACESHIP_ROOT/sections/git_branch.zsh"
 source "$SPACESHIP_ROOT/sections/git_status.zsh"
+source "$SPACESHIP_ROOT/sections/git_state.zsh"
 source "$SPACESHIP_ROOT/sections/git_commit.zsh"
 
 spaceship::precompile "$SPACESHIP_ROOT/sections/git_branch.zsh"
 spaceship::precompile "$SPACESHIP_ROOT/sections/git_status.zsh"
+spaceship::precompile "$SPACESHIP_ROOT/sections/git_state.zsh"
 spaceship::precompile "$SPACESHIP_ROOT/sections/git_commit.zsh"
 
 # ------------------------------------------------------------------------------
 # Section
 # ------------------------------------------------------------------------------
 
-# Show both git branch and git status:
+# Show git branch, status, state, and commit:
 #   spaceship_git_branch
 #   spaceship_git_status
+#   spaceship_git_state
 spaceship_git() {
   [[ $SPACESHIP_GIT_SHOW == false ]] && return
 

--- a/sections/git_state.zsh
+++ b/sections/git_state.zsh
@@ -1,0 +1,59 @@
+#
+# Git state
+#
+# Show active git operation state (rebase, merge, revert, am, cherry-pick, bisect).
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+SPACESHIP_GIT_STATE_SHOW="${SPACESHIP_GIT_STATE_SHOW=true}"
+SPACESHIP_GIT_STATE_ASYNC="${SPACESHIP_GIT_STATE_ASYNC=false}"
+SPACESHIP_GIT_STATE_PREFIX="${SPACESHIP_GIT_STATE_PREFIX=" ["}"
+SPACESHIP_GIT_STATE_SUFFIX="${SPACESHIP_GIT_STATE_SUFFIX="]"}"
+SPACESHIP_GIT_STATE_COLOR="${SPACESHIP_GIT_STATE_COLOR="red"}"
+SPACESHIP_GIT_STATE_REBASE_REBASING="${SPACESHIP_GIT_STATE_REBASE_REBASING="rebase"}"
+SPACESHIP_GIT_STATE_REBASE_APPLYING="${SPACESHIP_GIT_STATE_REBASE_APPLYING="am"}"
+SPACESHIP_GIT_STATE_MERGING="${SPACESHIP_GIT_STATE_MERGING="merge"}"
+SPACESHIP_GIT_STATE_REVERTING="${SPACESHIP_GIT_STATE_REVERTING="revert"}"
+SPACESHIP_GIT_STATE_CHERRY_PICKING="${SPACESHIP_GIT_STATE_CHERRY_PICKING="cherry-pick"}"
+SPACESHIP_GIT_STATE_BISECTING="${SPACESHIP_GIT_STATE_BISECTING="bisect"}"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+spaceship_git_state() {
+  [[ $SPACESHIP_GIT_STATE_SHOW == false ]] && return
+
+  spaceship::is_git || return
+
+  local git_dir="$(command git rev-parse --git-dir 2>/dev/null)"
+  local git_state=""
+
+  if [[ -d "$git_dir/rebase-merge" ]]; then
+    git_state="$SPACESHIP_GIT_STATE_REBASE_REBASING"
+  elif [[ -d "$git_dir/rebase-apply" ]]; then
+    if [[ -f "$git_dir/rebase-apply/applying" ]]; then
+      git_state="$SPACESHIP_GIT_STATE_REBASE_APPLYING"
+    else
+      git_state="$SPACESHIP_GIT_STATE_REBASE_REBASING"
+    fi
+  elif [[ -f "$git_dir/MERGE_HEAD" ]]; then
+    git_state="$SPACESHIP_GIT_STATE_MERGING"
+  elif [[ -f "$git_dir/REVERT_HEAD" ]]; then
+    git_state="$SPACESHIP_GIT_STATE_REVERTING"
+  elif [[ -f "$git_dir/CHERRY_PICK_HEAD" ]]; then
+    git_state="$SPACESHIP_GIT_STATE_CHERRY_PICKING"
+  elif [[ -f "$git_dir/BISECT_LOG" ]]; then
+    git_state="$SPACESHIP_GIT_STATE_BISECTING"
+  fi
+
+  [[ -z "$git_state" ]] && return
+
+  spaceship::section \
+    --color "$SPACESHIP_GIT_STATE_COLOR" \
+    --prefix "$SPACESHIP_GIT_STATE_PREFIX" \
+    --suffix "$SPACESHIP_GIT_STATE_SUFFIX" \
+    "$git_state"
+}

--- a/tests/git_state.test.zsh
+++ b/tests/git_state.test.zsh
@@ -1,0 +1,170 @@
+#!/usr/bin/env zsh
+
+# Required for shunit2 to run correctly
+setopt shwordsplit
+SHUNIT_PARENT=$0
+
+# ------------------------------------------------------------------------------
+# SHUNIT2 HOOKS
+# ------------------------------------------------------------------------------
+
+oneTimeSetUp() {
+  export TERM="xterm-256color"
+  export PATH=$PWD/tests/stubs:$PATH
+
+  SPACESHIP_PROMPT_ASYNC=false
+  SPACESHIP_PROMPT_FIRST_PREFIX_SHOW=true
+  SPACESHIP_PROMPT_ADD_NEWLINE=false
+  SPACESHIP_PROMPT_ORDER=(git)
+
+  source "spaceship.zsh"
+}
+
+setUp() {
+  SPACESHIP_GIT_SHOW="true"
+  SPACESHIP_GIT_PREFIX="on "
+  SPACESHIP_GIT_SUFFIX=""
+  SPACESHIP_GIT_SYMBOL=" "
+
+  SPACESHIP_GIT_STATE_SHOW="true"
+  SPACESHIP_GIT_STATE_PREFIX=" ["
+  SPACESHIP_GIT_STATE_SUFFIX="]"
+  SPACESHIP_GIT_STATE_COLOR="red"
+  SPACESHIP_GIT_STATE_REBASE_REBASING="rebase"
+  SPACESHIP_GIT_STATE_REBASE_APPLYING="am"
+  SPACESHIP_GIT_STATE_MERGING="merge"
+  SPACESHIP_GIT_STATE_REVERTING="revert"
+  SPACESHIP_GIT_STATE_CHERRY_PICKING="cherry-pick"
+  SPACESHIP_GIT_STATE_BISECTING="bisect"
+
+  cd $SHUNIT_TMPDIR
+}
+
+oneTimeTearDown() {
+  unset SPACESHIP_PROMPT_FIRST_PREFIX_SHOW
+  unset SPACESHIP_PROMPT_ADD_NEWLINE
+  unset SPACESHIP_PROMPT_ORDER
+}
+
+tearDown() {
+  unset SPACESHIP_GIT_SHOW
+  unset SPACESHIP_GIT_PREFIX
+  unset SPACESHIP_GIT_SUFFIX
+  unset SPACESHIP_GIT_SYMBOL
+
+  unset SPACESHIP_GIT_STATE_SHOW
+  unset SPACESHIP_GIT_STATE_PREFIX
+  unset SPACESHIP_GIT_STATE_SUFFIX
+  unset SPACESHIP_GIT_STATE_COLOR
+  unset SPACESHIP_GIT_STATE_REBASE_REBASING
+  unset SPACESHIP_GIT_STATE_REBASE_APPLYING
+  unset SPACESHIP_GIT_STATE_MERGING
+  unset SPACESHIP_GIT_STATE_REVERTING
+  unset SPACESHIP_GIT_STATE_CHERRY_PICKING
+  unset SPACESHIP_GIT_STATE_BISECTING
+}
+
+# ------------------------------------------------------------------------------
+# HELPERS
+# ------------------------------------------------------------------------------
+
+init_git_repo() {
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "Test User"
+  echo "init" > file.txt
+  git add file.txt
+  git commit -q -m "initial commit"
+}
+
+# ------------------------------------------------------------------------------
+# TEST CASES
+# ------------------------------------------------------------------------------
+
+test_git_state_no_repo() {
+  local no_state_expected=""
+  local no_state_actual="$(spaceship::testkit::render_prompt)"
+  assertEquals "should not render state outside git repo" "$no_state_expected" "$no_state_actual"
+}
+
+test_git_state_clean() {
+  init_git_repo
+  local state_part="$(spaceship_git_state)"
+  local clean_expected=""
+  assertEquals "should return empty string in clean repo" "$clean_expected" "$state_part"
+}
+
+test_git_state_rebase_merge() {
+  init_git_repo
+  mkdir -p .git/rebase-merge
+  touch .git/rebase-merge/done
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "rebase"
+  rm -rf .git/rebase-merge
+}
+
+test_git_state_rebase_apply() {
+  init_git_repo
+  mkdir -p .git/rebase-apply
+  touch .git/rebase-apply/applying
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "am"
+  rm -rf .git/rebase-apply
+}
+
+test_git_state_rebase_applying() {
+  init_git_repo
+  mkdir -p .git/rebase-apply
+  touch .git/rebase-apply/done
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "rebase"
+  rm -rf .git/rebase-apply
+}
+
+test_git_state_merge() {
+  init_git_repo
+  echo "merge-head" > .git/MERGE_HEAD
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "merge"
+  rm .git/MERGE_HEAD
+}
+
+test_git_state_revert() {
+  init_git_repo
+  echo "revert-head" > .git/REVERT_HEAD
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "revert"
+  rm .git/REVERT_HEAD
+}
+
+test_git_state_cherry_pick() {
+  init_git_repo
+  echo "cherry-pick-head" > .git/CHERRY_PICK_HEAD
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "cherry-pick"
+  rm .git/CHERRY_PICK_HEAD
+}
+
+test_git_state_bisect() {
+  init_git_repo
+  echo "bisect log" > .git/BISECT_LOG
+  local state_part="$(spaceship_git_state)"
+  assertContains "$state_part" "bisect"
+  rm .git/BISECT_LOG
+}
+
+test_git_state_hidden_when_disabled() {
+  init_git_repo
+  SPACESHIP_GIT_STATE_SHOW="false"
+  echo "merge-head" > .git/MERGE_HEAD
+  local state_part="$(spaceship_git_state)"
+  assertEquals "" "$state_part"
+  rm .git/MERGE_HEAD
+}
+
+# ------------------------------------------------------------------------------
+# SHUNIT2
+# Run tests with shunit2
+# ------------------------------------------------------------------------------
+
+source tests/shunit2/shunit2


### PR DESCRIPTION
Add a new git_state subsection that detects and displays active git operations such as rebase, merge, revert, am, cherry-pick, and bisect.

Closes #1215

<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR. -->

#### Description

<!-- Describe your pull-request, what was changed and why… -->

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
